### PR TITLE
Changing the license to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/SAP/techne.git"
   },
   "author": "Hybris Software",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "gulp-connect-multi": "^1.0.8"
   },


### PR DESCRIPTION
The LICENSE file shows Apache-2.0 and the package.json MIT. That should be the same license. 