### PR TITLE
CCE-347 : Cookie bar z-index fix. 

### DIFF
--- a/docs/template/public/kss.less
+++ b/docs/template/public/kss.less
@@ -1614,5 +1614,5 @@ body.hyComponentsPage{
 
 // cookie bar fix 
 .yg-cookie-bar{
-    z-index: 103!important;
+    z-index: 902!important;
 }


### PR DESCRIPTION
902 seems to be the magic number to have it sit above everything else