### PR TITLE
add a new label-warning using default orange color

### DIFF
--- a/src/less/overwrites/_labels.less
+++ b/src/less/overwrites/_labels.less
@@ -16,7 +16,7 @@
 @label-default-color: @label-color;
 @label-success-color: @default-green;
 @label-danger-color: @default-red;
-
+@label-warning-color: @default-orange;
 
 .label{
   font-size: 12px;
@@ -39,6 +39,10 @@
 
 .label-danger {
   .label-variant-custom(@label-danger-bg, @label-danger-color);
+}
+
+.label-warning {
+  .label-variant-custom(@label-default-bg, @label-warning-color);
 }
 
 // Activity Status


### PR DESCRIPTION
labels have too few colors by default, only 3 available states and intermediate one would be an improvement.