### PR TITLE
CCE-528: Fix the underline on hover in IE and for pagination

### DIFF
--- a/src/less/overwrites/_buttons.less
+++ b/src/less/overwrites/_buttons.less
@@ -68,6 +68,13 @@
   }
 }
 
+.btn-link {
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
+}
+
 // Button variants
 // -------------------------
 // with more parameter so you get full controll over hover etc states

--- a/src/less/overwrites/_pagination.less
+++ b/src/less/overwrites/_pagination.less
@@ -124,7 +124,7 @@
     > a,
     > span{
       &:hover{
-        text-decoration: underline;
+        text-decoration: none;
       }
     }
 


### PR DESCRIPTION
Hi @jeremytrawls,

Here are the changes I made:
* no underline on hover and on focus for btn-link (appears mostly in IE)
* no underline on hover for pagination (there is already a change of color)

Thank you,
Andreea