### PR TITLE
CCE-543, refactor the section inline level help tooltip classes

### DIFF
--- a/src/less/components/_forms-help.less
+++ b/src/less/components/_forms-help.less
@@ -200,7 +200,7 @@
         display: block;
         margin-bottom: 0;
     }
-    .form-readonly-text{
+    .form-readonly-text, .form-readonly-text__inline {
         display: inline-block;
     }
     .help-icon-inline {

--- a/src/less/components/_forms-help.less
+++ b/src/less/components/_forms-help.less
@@ -162,7 +162,10 @@
 
 .help-inline--section{
    &.help-inline--tooltip{
-      margin-bottom: 0;
+     margin-bottom: 0;
+     display: inline-block;
+     float: none;
+     position: relative;
       // on mobile the icon and tooltip float right
       @media (max-width: @screen-xs) {
           float: right;
@@ -183,32 +186,26 @@
 // Markup:
 // <div class="form-group form-group__inline">
 //     <label class="control-label">Service Name</label>
-//     <div class="form-readonly-text form-readonly-text__inline">read-only content styling with inline level help </div>
-//     <span class="section-help help-inline help-inline--section help-inline--tooltip section-help--tooltip__inline">
+//     <div class="form-readonly-text">read-only content styling with inline level help </div>
+//     <span class="section-help help-inline help-inline--section help-inline--tooltip">
 //         <span class="hyicon hyicon-helpoff help-icon-inline"></span>
 //         <span class="help-block-inline">I'm a additional Inline Help Text - inlined</span>
 //     </span>
 // </div>
 //
-// Component 5.7
+// Component 5.8
 
 .form-group__inline{
     label{
         display: block;
         margin-bottom: 0;
     }
-    .form-readonly-text__inline{
+    .form-readonly-text{
         display: inline-block;
     }
-    .section-help--tooltip__inline{
-        display: inline-block;
-        float: none;
-        position: relative;
-
-        .help-icon-inline {
-            &:before {
-                margin-top: 5px;
-            }
+    .help-icon-inline {
+        &:before {
+            margin-top: 5px;
         }
     }
 }

--- a/src/less/components/_forms-validationandhelp.less
+++ b/src/less/components/_forms-validationandhelp.less
@@ -5,7 +5,7 @@
 // Markup:
 // <div class="form-group has-error">
 //     <label for="exampleInputEmail1" class="control-label required">Email address</label>
-//     <input type="email" class="has-error form-control input-lg" id="exampleInputEmail1" placeholder="Email" required>
+//     <input type="email" class="form-control input-lg" id="exampleInputEmail1" placeholder="Email" required>
 //     <div class="help-block">
 //        <p ng-message="required" class="ng-binding ng-scope">Email address required</p>
 //     </div>


### PR DESCRIPTION
to reduce amount of classes used for styling the refactoring was made, mainly only for the section 5.8 (Section Inline Level help for read-only fields)