### PR TITLE
Feature/cce 639 implement scripts

### DIFF
--- a/docs/styleguide/scripts/main.js
+++ b/docs/styleguide/scripts/main.js
@@ -1,5 +1,5 @@
 /**
  * Created by d063436 on 5/21/17.
  */
-console.log("Just for js test purpose");
+console.log('Just for js test purpose');
 

--- a/docs/styleguide/templates/master.html
+++ b/docs/styleguide/templates/master.html
@@ -8,10 +8,6 @@
 {% block css %}
 
 {% endblock %}
-      <script src="js/techne-{% if debug %}debug{% else %}all{% endif %}{% if env == 'production' %}.min{% endif %}.js"></script>
-{% block js %}
-
-{% endblock %}
   </head>
   <body id="app--{{ app.id }}">
   <!--
@@ -64,5 +60,9 @@ _gaq.push(['_setAccount', 'UA-00000000-0']); _gaq.push(['_trackPageview']);
 })();
     </script>
 {% endif %}
+<script src="js/techne-styleguide{% if env == 'production' %}.min{% endif %}.js"></script>
+{% block js %}
+
+{% endblock %}
   </body>
 </html>

--- a/docs/styleguide/templates/master.html
+++ b/docs/styleguide/templates/master.html
@@ -2,10 +2,14 @@
 <html lang="en-us">
   <head>
 {% include "app_meta.html" %}
-	<link rel="stylesheet" href="css/techne-{% if debug %}debug{% else %}all{% endif %}{% if env == "production" %}.min{% endif %}.css">
+	<link rel="stylesheet" href="css/techne-{% if debug %}debug{% else %}all{% endif %}{% if env == 'production' %}.min{% endif %}.css">
 
     <link rel="stylesheet" href="css/techne-styleguide.css">
 {% block css %}
+
+{% endblock %}
+      <script src="js/techne-{% if debug %}debug{% else %}all{% endif %}{% if env == 'production' %}.min{% endif %}.js"></script>
+{% block js %}
 
 {% endblock %}
   </head>

--- a/ops/gulp/dev-serve.js
+++ b/ops/gulp/dev-serve.js
@@ -14,6 +14,7 @@ const task = () => {
     });
 	browserSync.watch(`./www/**/*.html`).on('change', browserSync.reload);
 	browserSync.watch(`./www/css/**/*.css`).on('change', browserSync.reload);
+	browserSync.watch(`./www/js/**/*.js`).on('change', browserSync.reload);
 }
 
 gulp.task('dev-serve', task);

--- a/ops/gulp/dev-watch.js
+++ b/ops/gulp/dev-watch.js
@@ -21,6 +21,9 @@ const task = () => {
 	//update styleguide styles
 	gulp.watch([`./docs/styleguide/styles/*.scss`], ['docs-styleguide']);
 
+	//watch docs js
+	gulp.watch([`./src/scripts/*.js`,`./ops/gulp/*.js`], ['docs-js']);
+
 }
 
 gulp.task('dev-watch', task);

--- a/ops/gulp/dev-watch.js
+++ b/ops/gulp/dev-watch.js
@@ -22,7 +22,7 @@ const task = () => {
 	gulp.watch([`./docs/styleguide/styles/*.scss`], ['docs-styleguide']);
 
 	//watch docs js
-	gulp.watch([`./src/scripts/*.js`,`./ops/gulp/*.js`], ['docs-js']);
+	gulp.watch(`./docs/styleguide/scripts/*.js`, ['docs-js']);
 
 }
 

--- a/ops/gulp/docs-build.js
+++ b/ops/gulp/docs-build.js
@@ -5,7 +5,7 @@ let environment = require('../lib/environment');
 
 const task = (cb) => {
 
-    gulpSequence('pkg-build', 'docs-clean', ['docs-resources', 'docs-html', 'docs-css', 'docs-styleguide'], cb);
+    gulpSequence('pkg-build', 'docs-clean', ['docs-resources', 'docs-html', 'docs-css', 'docs-styleguide', 'docs-js'], cb);
 
 }
 

--- a/ops/gulp/docs-css.js
+++ b/ops/gulp/docs-css.js
@@ -12,7 +12,6 @@ let techneCss = environment.production ? 'techne-all.min.css' : 'techne-all.css'
 let debugSrc = environment.debug ? [`${paths.src}/techne-debug.css`] : [];
 
 const task = (cb) => {
-
     return gulp.src([`${paths.src}/${techneCss}`,...debugSrc])
 		.pipe(gulp.dest(paths.dest));
 

--- a/ops/gulp/docs-js.js
+++ b/ops/gulp/docs-js.js
@@ -3,23 +3,30 @@ const gp_concat = require('gulp-concat');
 const gp_rename = require('gulp-rename');
 const gp_uglify = require('gulp-uglify');
 const gulpif = require('gulp-if');
-const gulp_jslint = require('gulp-jslint');
+const gulp_eslint = require('gulp-eslint');
 
 let environment = require('../lib/environment');
 
 const paths = {
-    src: './src/scripts',
+    src: './docs/styleguide/scripts',
     dest: './www/js'
 }
 
-let techneDestJS = environment.production ? 'techne-all.min.js' : 'techne-all.js';
+let techneDestJS = environment.production ? 'techne-styleguide.min.js' : 'techne-styleguide.js';
 
 const task = (cb) => {
     return gulp.src([`${paths.src}/*`])
-        .pipe(gulp_jslint())
+        .pipe(gulp_eslint({
+            'rules': {
+                'quotes': [1, 'single'],
+                'semi': [1, 'always']
+            }
+        }))
         .pipe(gp_concat('concat.js'))
         .pipe(gulpif(environment.production, gp_uglify('uglify.js')))
         .pipe(gp_rename(techneDestJS))
+        .pipe(gulp_eslint.format())
+        .pipe(gulp_eslint.failOnError())
         .pipe(gulp.dest(paths.dest));
 }
 

--- a/ops/gulp/docs-js.js
+++ b/ops/gulp/docs-js.js
@@ -1,0 +1,27 @@
+const gulp = require('gulp');
+const gp_concat = require('gulp-concat');
+const gp_rename = require('gulp-rename');
+const gp_uglify = require('gulp-uglify');
+const gulpif = require('gulp-if');
+const gulp_jslint = require('gulp-jslint');
+
+let environment = require('../lib/environment');
+
+const paths = {
+    src: './src/scripts',
+    dest: './www/js'
+}
+
+let techneDestJS = environment.production ? 'techne-all.min.js' : 'techne-all.js';
+
+const task = (cb) => {
+    return gulp.src([`${paths.src}/*`])
+        .pipe(gulp_jslint())
+        .pipe(gp_concat('concat.js'))
+        .pipe(gulpif(environment.production, gp_uglify('uglify.js')))
+        .pipe(gp_rename(techneDestJS))
+        .pipe(gulp.dest(paths.dest));
+}
+
+gulp.task('docs-js', task);
+module.exports = task;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-sequence": "^0.4.6",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-uglify": "^3.0.0",
-    "gulp-jslint": "^1.0.10",
+    "gulp-eslint": "^3.0.1",
     "path": "^0.12.7",
     "require-dir": "^0.3.1",
     "yargs": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "gulp-sass": "^3.1.0",
     "gulp-sequence": "^0.4.6",
     "gulp-sourcemaps": "^2.6.0",
+    "gulp-uglify": "^3.0.0",
+    "gulp-jslint": "^1.0.10",
     "path": "^0.12.7",
     "require-dir": "^0.3.1",
     "yargs": "^7.0.2"

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,0 +1,5 @@
+/**
+ * Created by d063436 on 5/21/17.
+ */
+console.log("Just for js test purpose");
+


### PR DESCRIPTION
gulp task for compiling JS files is created. It works fine with gulp docs-js, and gulp docs-js --production and creates techne-all.js and techne-all.min.js respectively. The only one thing is that with npm start --production the environment.production variable set to false therefore I used gulp docs-js --production to test the gulp task.