### PR TITLE
V2.0 gh pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js: 
+  - node
+install:
+ - npm install
+ - npm install gulp -g
+script:
+ - gulp docs-build --production
+after_success:
+ - gulp deploy
+branches:
+  only: 
+    - v2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: 
-  - node
+  - 7
 install:
  - npm install
  - npm install gulp -g

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
 script:
  - gulp docs-build --production
 after_success:
+ - git config --global user.name "Travis CI Test"
+ - git config --global user.email "test@test.com"
  - gulp deploy
 branches:
   only: 

--- a/ops/gulp/ghpages-deploy.js
+++ b/ops/gulp/ghpages-deploy.js
@@ -1,0 +1,9 @@
+var gulp = require('gulp');
+var ghPages = require('gulp-gh-pages');
+
+//Task for deploying compiled HTML to gh-pages branch for GitHub Pages hosting
+gulp.task('deploy', function() {
+    
+  return gulp.src('./www/**/*')
+    .pipe(ghPages());
+});

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-svg-sprites": "^4.1.1",
     "gulp-svgmin": "^1.2.4",
     "gulp-uglify": "^3.0.0",
+    "gulp-gh-pages": "0.5.4",
     "path": "^0.12.7",
     "require-dir": "^0.3.1",
     "sass": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "",
   "devDependencies": {
+    "bower": "^1.7.9",
     "browser-sync": "^2.18.8",
     "del": "^2.2.2",
     "gulp": "^3.9.1",


### PR DESCRIPTION
This is initial configuration. We are missing ssh key for travis push operation. I'll do it once you accept and merge this pull request.
- travis file is needed for travis to know what to do
- I noticed you use gulp extensively so there was no point to write custom sh script but just use available gulp plugins
- except of new gulp plugin I had to add bower to dependencies as only gulp was there