### PR TITLE
#795 styles for inputs and textarea; adds form component

### DIFF
--- a/ops/misc/src-tmpl.html
+++ b/ops/misc/src-tmpl.html
@@ -1,19 +1,17 @@
 <!--
 __COMPONENT_METHOD__:
-    label="", (string)
-    description="", (string | optional)
-    modifier="" (string | optional)
+    properties={},
+    modifier={},
+    state={},
+    aria={}
 -->
-{% macro __COMPONENT_METHOD__(
-    label="",
-    description="",
-    modifier="") %}
-<div class="tn-__COMPONENT_ID__{{ '--' + modifier if modifier }}">
+{% macro __COMPONENT_METHOD__(properties={}, modifier={}, state={}, aria={}) %}
+<div class="tn-__COMPONENT_ID__{{ modifier.block | modifier('__COMPONENT_ID__') }}">
     <p>
-        {{ label }}
-        {% if description %}
+        {{ properties.label }}
+        {%- if properties.description %}
             <br>
-            {{ description }}
+            {{ properties.description }}
         {% endif %}
     </p>
 </div>

--- a/ops/misc/src-tmpl.json
+++ b/ops/misc/src-tmpl.json
@@ -1,12 +1,18 @@
 {
     "id": "__COMPONENT_ID__",
     "name": "__COMPONENT_NAME__",
-    "modifiers": [
-        "no-border"
-    ],
-    "data": {
+    "properties": {
         "label": "__COMPONENT_NAME__ Label",
         "description": "__COMPONENT_NAME__ Description"
+    },
+    "modifier": {
+        "block": ["no-border"]
+    },
+    "state": {
+
+    },
+    "aria": {
+
     }
 
 }

--- a/ops/misc/src-tmpl.scss
+++ b/ops/misc/src-tmpl.scss
@@ -3,18 +3,17 @@
 @import "../core/functions";
 
 /*!
-    __COMPONENT_ID__ structure
-    .tn-__COMPONENT_ID__+(--no-border)
-        .tn-__COMPONENT_ID____content+()
-        .tn-__COMPONENT_ID____title+()
+.tn-__COMPONENT_ID__+(--no-border)
+    .tn-__COMPONENT_ID____content+()
+    .tn-__COMPONENT_ID____title+()
 */
 $block: ns(__COMPONENT_ID__);
 
 .#{$block} {
     //LOCAL VARS (set all vars used in component, always include !default)
-    $tn-__COMPONENT_ID__-color-border: color(light) !default;
-    $tn-__COMPONENT_ID__-color-border-content: color(dark) !default;
-    $tn-__COMPONENT_ID__-color-selected: color(brand) !default;
+    $tn-__COMPONENT_ID__-color-border: tn-color(neutral,3) !default;
+    $tn-__COMPONENT_ID__-color-border-content: tn-color(neutral,4) !default;
+    $tn-__COMPONENT_ID__-color-selected: tn-color(primary) !default;
 
     //BLOCK BASE *******************************************
     //set all BLOCK reset and baseline styles

--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -1,3 +1,3 @@
 @import "components/button";
 @import "components/card";
-// @import "components/table";
+@import "components/form";

--- a/src/styles/components/form.scss
+++ b/src/styles/components/form.scss
@@ -1,0 +1,156 @@
+@import "../core/settings";
+@import "../core/mixins";
+@import "../core/functions";
+
+/*!
+.tn-form
+    .tn-form__group()
+        .tn-form__legend()
+        .tn-form__item+(--check, --inline)
+            .tn-form__label(.is-required)
+            .tn-form__control((.is-valid | .is-invalid | .is-warning), (.is-disabled|[disabled]), (.is-readonly|[readonly]))
+        .tn-form__message(--help, --error, --warning)
+*/
+$block: ns(form);
+
+.#{$block} {
+    //LOCAL VARS (set all vars used in component, always include !default)
+    $tn-form-item-gutter: $tn-width--gutter !default;
+
+
+    //BLOCK BASE *******************************************
+    //set all BLOCK reset and baseline styles
+
+
+    //BLOCK MODIFIERS ************
+    //each mod MUST extend base block so devs can use a single class and get all base styles for free
+
+
+    //ELEMENTS *******************************************
+    //set all ELEMENT baseline styles
+    &__group {
+        @include clearfix;
+        @include tn-last-child;
+        margin-bottom: $tn-margin-bottom;
+
+        //ELEMENT MODIFIERS ************
+        //each mod MUST extend the element base
+
+    }
+    &__item {
+        @include tn-last-child;
+        margin-right: $tn-form-item-gutter;
+        &--check {
+            @include clearfix;
+            position: relative;
+            display: block;
+            margin-bottom: tn-space(5);
+            .#{$block}__label {
+                margin-bottom: 0;
+                margin-top: tn-space(1);
+                float: left;
+                width: calc(100% - #{tn-space(10)});
+            }
+            .#{$block}__control {
+                float: left;
+                &:focus {
+                    & + .#{$block}__label {
+                        color: tn-color(text);
+                    }
+                }
+            }
+        }
+        &--inline {
+            float: left;
+            margin-bottom: 0;
+            .#{$block}__label {
+                margin-bottom: 0;
+                margin-top: tn-space(1);
+                float: left;
+                width: auto;
+            }
+        }
+    }
+    &__label, &__legend {
+        display: block;
+        margin-bottom: tn-space(3);
+        @include tn-type(-1);
+        color: tn-color(text, 3);
+        &.is-required {
+            @include tn-weight(bold);
+        }
+    }
+    &__legend {
+        margin-bottom: tn-space(5);
+    }
+    &__message {
+        clear: both;
+        display: block;
+        @include tn-type(-1);
+        color: tn-color(text, 2);
+        padding: tn-space(1) 0;
+
+        font-style: italic;
+        position: relative;
+        //adjust for checks
+        @at-root {
+            .#{$block}__item--check + & {
+                transform: translateY(-(tn-space(3)));
+                margin-bottom: -(tn-space(3));
+            }
+            .#{$block}__item--inline.#{$block}__item--check + & {
+                transform: translateY(tn-space(2));
+                margin-bottom: tn-space(2);
+            }
+        }
+        &::before {
+            width: 18px;
+            height: 18px;
+            font-style: normal;
+            position: absolute;
+            left: 0;
+            color: tn-color(text-inverse);
+            border-radius: 50%;
+            background-color: tn-color(text, 3);
+            text-align: center;
+        }
+        &--help {
+            padding-left: tn-space(7);
+            &::before {
+                content: "?";
+            }
+        }
+        &--warning, &--error {
+            padding-left: tn-space(9);
+            color: tn-color(text);
+            &::before {
+                content: "!";
+                left: tn-space(2);
+            }
+        }
+        &--warning {
+            background-color: tn-color(status,4);
+            &::before {
+                background-color: transparent;
+                border-radius: 0;
+                @include triangle(20px 18px, tn-color(status, 3), up);
+                text-indent: -0.1em;
+            }
+        }
+        &--error {
+            background-color: tn-color(status,6);
+            &::before {
+                background-color: tn-color(status, 5);
+                color: tn-color(text-inverse);
+            }
+        }
+    }
+
+    //STATES *******************************************
+    //these classes and attributes can be modified by scripts
+
+
+
+
+
+}

--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -1,2 +1,2 @@
 @import "core/elements";
-
+@import "core/forms";

--- a/src/styles/core/_mixins.scss
+++ b/src/styles/core/_mixins.scss
@@ -13,6 +13,14 @@ $ns: ns();
     }
 }
 
+@mixin tn-last-child {
+    &:last-child {
+        margin-bottom: 0;
+        margin-right: 0;
+        @content;
+    }
+}
+
 @mixin tn-at-media($size, $dimension: width) {
   @if map-has-key($tn-breakpoints, $size) {
     @media (min-#{$dimension}: map-get($tn-breakpoints, $size)) {

--- a/src/styles/core/elements.scss
+++ b/src/styles/core/elements.scss
@@ -110,3 +110,27 @@ fieldset {
     padding: 0;
     margin: 0;
 }
+
+// select {
+//     appearance: none;
+//     background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI2IiB2aWV3Qm94PSIwIDAgOSA2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik00LjY2MiA1Ljg3M2wtLjAxMi4wMUwuMzQ1IDEuNThsLjg1LS44NTIgMy40NzcgMy40NzZMOC4xMzguNzRsLjg1Ljg1LTQuMzA0IDQuMzA1LS4wMjItLjAyMnoiIGZpbGw9InJnYmEoMTQ0LCAxNDQsIDE0NSwgMS4wKSIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9zdmc+');
+//     background-repeat: no-repeat;
+//     background-position: calc(100% - 0.8em) center;
+//     padding-right: 25px;
+//     &.is-invalid {
+//         border-color: $tn-forms-color--invalid;
+//         background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI2IiB2aWV3Qm94PSIwIDAgOSA2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjx0aXRsZT5jaXJjdW1mbGV4LWludmVydGVkPC90aXRsZT48cGF0aCBkPSJNNC42NjIgNS44NzNsLS4wMTIuMDFMLjM0NSAxLjU4bC44NS0uODUyIDMuNDc3IDMuNDc2TDguMTM4Ljc0bC44NS44NS00LjMwNCA0LjMwNS0uMDIyLS4wMjJ6IiBmaWxsPSJyZ2JhKDIwNCwgMTI0LCAxMjcsIDEuMCkiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==');
+//     }
+// }
+
+@-moz-document url-prefix() {
+    // Firefox
+    select {
+    }
+}
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    // IE10+ specific styles go here
+    select {
+        padding-right: 0;
+    }
+}

--- a/src/styles/core/forms.scss
+++ b/src/styles/core/forms.scss
@@ -1,0 +1,166 @@
+@import "settings";
+@import "mixins";
+
+$tn-elements-inputs--text: "[type=text]", "[type=password]", "[type=email]", "[type=url]", "[type=search]", "[type=tel]", "[type=number]", "[type=date]";
+$tn-elements-inputs--check: "[type=radio]", "[type=checkbox]";
+
+//dimensions
+$tn-forms-height--input-text: tn-space(13) !default;
+$tn-forms-height--input-check: tn-space(6.5) !default;
+//colors
+$tn-forms-color: $tn-color !default;
+$tn-forms-color--placeholder: tn-color(text,3) !default;
+$tn-forms-color--focus: $tn-forms-color !default;
+$tn-forms-color--valid: tn-color(status,1) !default;
+$tn-forms-color--invalid: tn-color(status,5) !default;
+$tn-forms-color--warning: tn-color(status,3) !default;
+$tn-forms-color--disabled: tn-color(text,3) !default;
+$tn-forms-background-color: tn-color(background,1) !default;
+$tn-forms-background-color--check: tn-color(action,1);
+$tn-forms-background-color--check-disabled: tn-color(text,2);
+$tn-forms-background-color--disabled: tn-color(neutral,1) !default;
+$tn-forms-border-color: tn-color(neutral,2) !default;
+$tn-forms-border-color--check: tn-color(action,1);
+$tn-forms-border-color--focus: tn-color(action,1) !default;
+$tn-forms-border-color--disabled: tn-color(neutral,2) !default;
+//anim
+$tn-forms-transition-params: 0.25s ease-in;
+
+%form-field-base {
+    @include reset;
+    @include tn-type(0,body);
+    -webkit-appearance: textfield;
+    font-size: inherit;
+    appearance: none;
+    box-sizing: border-box;
+    outline: none;
+    border-style: solid;
+    border-width: 1px;
+    border-color: $tn-forms-border-color;
+    color: $tn-forms-color;
+    background-color: $tn-forms-background-color;
+    transition: border-color $tn-forms-transition-params, background-color $tn-forms-transition-params;
+    &::after {
+        transition: border-color $tn-forms-transition-params;
+    }
+    &::placeholder {
+        color: $tn-forms-color--placeholder;
+    }
+    //states
+    &:focus {
+        border-color: $tn-forms-border-color--focus;
+    }
+    &.is-invalid {
+        border-color: $tn-forms-color--invalid;
+    }
+    &.is-valid {
+        border-color: $tn-forms-color--valid;
+    }
+    &.is-warning {
+        border-color: $tn-forms-color--warning;
+    }
+    &[disabled],
+    &[aria-disabled="true"],
+    &.is-disabled {
+        cursor: not-allowed;
+        color: $tn-forms-color--disabled;
+        border-color: $tn-forms-border-color--disabled;
+        background-color: $tn-forms-background-color--disabled;
+    }
+    &[readonly],
+    &.is-readonly {
+        color: $tn-forms-color;
+        background-color: $tn-forms-background-color;
+        border-color: $tn-forms-border-color--disabled;
+        border-width: 0 0 1px;
+    }
+}
+// input[type="search"]::-webkit-search-decoration,
+// input[type="search"]::-webkit-search-cancel-button {
+//     -webkit-appearance: none;
+// }
+#{$tn-elements-inputs--text}, textarea, select {
+    @extend %form-field-base;
+    width: 100%;
+    height: $tn-forms-height--input-text;
+    padding-left: 1em;
+    padding-right: 1em;
+}
+textarea {
+    height: $tn-forms-height--input-text * 3;
+    padding-top: 1em;
+}
+#{$tn-elements-inputs--check} {
+    @extend %form-field-base;
+    height: $tn-forms-height--input-check;
+    width: $tn-forms-height--input-check;
+    //margin: (($tn-forms-height--input-text - $tn-forms-height--input-check) / 2) 0;
+    margin: 0;
+    margin-right: tn-space(3);
+    vertical-align: middle;
+    position: relative;
+    &:checked {
+        border-color: $tn-forms-border-color--check;
+        background-color: $tn-forms-border-color--check;
+    }
+    &[disabled],
+    &[aria-disabled="true"],
+    &.is-disabled {
+        border-color: $tn-forms-border-color--disabled;
+        background-color: $tn-forms-background-color--disabled;
+    }
+}
+[type="checkbox"] {
+    &:checked {
+        &::after {
+            content: "";
+            width: 16px;
+            height: 6px;
+            border-color: $tn-forms-background-color;
+            border-style: solid;
+            border-width: 0 0 1px 1px;
+            transform: rotate(-45deg);
+            position: absolute;
+            z-index: 2;
+            top: calc(50% - 5px);
+            left: calc(50% - 16px/2);
+        }
+        &[disabled],
+        &[aria-disabled="true"],
+        &.is-disabled {
+            &::after {
+                border-color: $tn-forms-background-color--check-disabled;
+            }
+        }
+    }
+}
+[type="radio"] {
+    border-radius: 50%;
+    &::after {
+        $check-size_: tn-space(4);
+        content: "";
+        border-radius: 50%;
+        width: $check-size_;
+        height: $check-size_;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        top: calc(50% - (#{$check-size_}/2));
+        left: calc(50% - (#{$check-size_}/2));
+        transition: background-color $tn-forms-transition-params;
+        background-color: $tn-forms-background-color;
+    }
+    &:checked {
+        background-color: $tn-forms-background-color;
+        &::after {
+            background-color: $tn-forms-background-color--check;
+        }
+        &[disabled],
+        &[aria-disabled="true"],
+        &.is-disabled {
+            &::after {
+                background-color: $tn-forms-background-color--check-disabled;
+            }
+        }
+    }
+}

--- a/test/app.js
+++ b/test/app.js
@@ -21,7 +21,7 @@ var env = nunjucks.configure([TEMPLATE_DIRECTORY,PUBLIC_DIRECTORY], {
     watch: true
 });
 // convert SASS to CSS from the lib source
-env.addFilter('sassToCss', function(sassFile="app.scss") {
+env.addFilter('sass_to_css', function(sassFile="app.scss") {
     try {
         var scss_filename = `${SASS_DIRECTORY}/${sassFile}`;
         return sass.renderSync({
@@ -32,12 +32,30 @@ env.addFilter('sassToCss', function(sassFile="app.scss") {
     }
 });
 // convert an array to classes
+// returns [ tn-element--mod ]
 env.addFilter('modifier', function(array=[],element="") {
+    //is string
+    if (typeof array === "string") {
+        return ` ${GLOBALS.namespace}-${element}--${array}`;
+    }
     var mods = array.map((mod) => {
          return ` ${GLOBALS.namespace}-${element}--${mod}`;
     })
     //console.log(mods.join());
     return mods.join('') ;
+});
+// convert an array to classes
+// returns [ tn-cls ]
+env.addFilter('classes', function(array=[]) {
+    //is string
+    if (typeof array === "string") {
+        return ` ${GLOBALS.namespace}-${array}`;
+    }
+    var classes = array.map((cls, index) => {
+         return ` ${GLOBALS.namespace}-${cls}`;
+    })
+    //console.log(mods.join());
+    return classes.join('') ;
 });
 
 app.set('views', TEMPLATE_DIRECTORY);

--- a/test/templates/form/component.njk
+++ b/test/templates/form/component.njk
@@ -1,0 +1,79 @@
+{% import "../forms.njk" as forms %}
+<!--
+form-group:
+    properties={},
+    modifier={},
+    state={},
+    aria={}
+-->
+{% macro form_group(
+    type="text",
+    properties={
+        legend: "",
+        label: "",
+        id: "",
+        message: "",
+        items: []
+    },
+    modifier={
+
+    },
+    state={
+        required: false
+    },
+    aria={})
+-%}
+<{{ 'fieldset' if type !== 'text' else 'div' }} class="tn-form__group{{ modifier.block | modifier('form__group') }}">
+{%- if properties.legend %}
+    <legend class="tn-form__legend{{ ' is-required' if state.required === true }}">{{ properties.legend }}</legend>
+{%- endif %}
+{%- for item in properties.items %}
+    <div class="tn-form__item{{ modifier.item | modifier('form__item') }}{{ ' tn-form__item--check' if type == "checkbox" or type == "radio" }}">
+        {%- if type == "checkbox" or type == "radio" %}
+        {{ form_control(type,properties=item.properties,state=item.state,aria=item.aria) | trim }}
+        <label class="tn-form__label{{ ' is-required' if item.state.required === true }}" for="{{ item.properties.id }}">{{item.properties.label}}</label>
+        {%- else %}
+        <label class="tn-form__label{{ ' is-required' if item.state.required === true }}" for="{{ item.properties.id }}">{{item.properties.label}}</label>
+        {{ form_control(type,properties=item.properties,state=item.state,aria=item.aria) | trim }}
+        {%- endif %}
+        {%- if item.properties.message %}
+        <span class="tn-form__message{{ item.modifier.message | modifier('form__message') }}">
+            {{item.properties.message}}
+        </span>
+        {%- endif %}
+    </div>
+{%- endfor %}
+{%- if properties.message %}
+<div class="tn-form__message {{ modifier.message | modifier('form__message') }}">
+    {{properties.message}}
+</div>
+{%- endif %}
+</{{ 'fieldset' if type !== 'text' else 'div' }}>
+{%- endmacro %}
+
+<!--
+form-control:
+    properties={},
+    modifier={},
+    state={},
+    aria={}
+-->
+{% macro form_control(
+    type="text",
+    properties={
+
+    },
+    modifier={},
+    state={},
+    aria={})
+-%}
+{%- if type == "textarea" -%}
+    {{ forms.textarea(properties,state=state,aria=aria,classes="form__control") }}
+{%- elif type == "radio" -%}
+    {{ forms.radio(properties,state=state,aria=aria,classes=["form__control"]) }}
+{%- elif type == "checkbox" -%}
+    {{ forms.checkbox(properties,state=state,aria=aria,classes=["form__control"]) }}
+{%- else -%}
+    {{ forms.text(type,properties,state=state,aria=aria, classes="form__control") }}
+{%- endif -%}
+{%- endmacro %}

--- a/test/templates/form/index.njk
+++ b/test/templates/form/index.njk
@@ -1,0 +1,536 @@
+{% extends "layout.njk" %}
+{% from "./component.njk" import form_group, form_control %}
+{% from "./../format.njk" import format %}
+
+{% block content %}
+
+<h1>Form — Inputs</h1>
+{% set example %}
+{{ form_group(
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-1"
+            }
+        }]
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-2"
+            },
+            state: {
+                required: true
+            }
+        }]
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-3"
+            },
+            state: {
+                status: "valid"
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            modifier: {
+                message: "error"
+            },
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-4",
+                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
+            },
+            state: {
+                status: "invalid"
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            modifier: {
+                message: "warning"
+            },
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-5",
+                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
+            },
+            state: {
+                status: "warning"
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-6"
+            },
+            state: {
+                disabled: true
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-7"
+            },
+            state: {
+                readonly: true
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    properties={
+        items: [{
+            modifier: {
+                message: "help"
+            },
+            properties: {
+                label: "Field Label",
+                placeholder: "Field placeholder text",
+                id: "input-4",
+                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
+            },
+            state: {
+                status: ""
+            }
+        }]
+
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+<h2>Inline</h2>
+{% set example %}
+{{ form_group(
+    modifier={
+        item: "inline",
+        message: "error"
+    },
+    properties={
+        message: "Error",
+        items: [{
+            properties: {
+                label: "First Name",
+                placeholder: "First Name",
+                id: "input-8"
+            }
+        },
+        {
+            properties: {
+                label: "Last Name",
+                placeholder: "Last Name",
+                id: "input-9"
+            }
+        }]
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+
+<h1>Form — Textarea</h1>
+{% set example %}
+{{ form_group(
+    "textarea",
+    properties={
+        items: [{
+            properties: {
+                label: "Field Label",
+                value: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem.",
+                id: "textarea-1"
+            }
+        }]
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+<h1>Form — Radio</h1>
+<h2>Stacked (Default)</h2>
+{% set example %}
+{{ form_group(
+    type="radio",
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "radio-1",
+                name: "radio-name-1",
+                label: "Option One"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-2",
+                name: "radio-name-1",
+                label: "Option Two"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "radio-3",
+                name: "radio-name-1",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    type="radio",
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "radio-4",
+                name: "radio-name-2",
+                label: "Option One"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "radio-5",
+                name: "radio-name-2",
+                label: "Option Two"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-5",
+                name: "radio-name-2",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    },
+    state={
+        required: true
+    })
+}}
+{{ form_group(
+    type="radio",
+    modifier={
+        message: "error"
+    },
+    properties={
+        legend: "Select an option",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.",
+        items: [
+        {
+            properties: {
+                id: "radio-7",
+                name: "radio-name-3",
+                label: "Option One"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "radio-8",
+                name: "radio-name-3",
+                label: "Option Two"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-9",
+                name: "radio-name-3",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    type="radio",
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "radio-10",
+                name: "radio-name-4",
+                label: "Option One"
+            },
+            state: {
+                checked: false,
+                disabled: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-11",
+                name: "radio-name-4",
+                label: "Option Two"
+            },
+            state: {
+                checked: true,
+                disabled: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-12",
+                name: "radio-name-4",
+                label: "Option Three"
+            },
+            state: {
+                checked: false,
+                disabled: true
+            }
+        }]
+
+    })
+}}
+
+
+
+
+{% endset %}
+{{ format(example) }}
+<h2>Inline</h2>
+{% set example %}
+{{ form_group(
+    type="radio",
+    modifier={
+        item: "inline"
+    },
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "radio-13",
+                name: "radio-name-5",
+                label: "Option One"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-14",
+                name: "radio-name-5",
+                label: "Option Two"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "radio-15",
+                name: "radio-name-5",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    })
+}}
+{{ form_group(
+    type="radio",
+    modifier={
+        item: "inline",
+        message: "warning"
+    },
+    properties={
+        legend: "Select an option",
+        message: "In tincidunt mi nisi nec faucibus tortor euismod nec. ",
+        items: [
+        {
+            properties: {
+                id: "radio-16",
+                name: "radio-name-6",
+                label: "Option One"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "radio-17",
+                name: "radio-name-6",
+                label: "Option Two"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "radio-18",
+                name: "radio-name-6",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+<h1>Form — Checkbox</h1>
+{% set example %}
+{{ form_group(
+    type="checkbox",
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "checkbox-1",
+                name: "checkbox-name-1",
+                label: "Option One"
+            },
+            state: {
+                checked: true
+            }
+        },
+        {
+            properties: {
+                id: "checkbox-2",
+                name: "checkbox-name-1",
+                label: "Option Two"
+            },
+            state: {
+                checked: false
+            }
+        },
+        {
+            properties: {
+                id: "checkbox-3",
+                name: "checkbox-name-1",
+                label: "Option Three"
+            },
+            state: {
+                checked: false
+            }
+        }]
+
+    })
+}}
+
+{{ form_group(
+    type="checkbox",
+    modifier={
+        item: "inline"
+    },
+    properties={
+        legend: "Select an option",
+        items: [
+        {
+            properties: {
+                id: "checkbox-4",
+                name: "checkbox-name-2",
+                label: "Option One"
+            },
+            state: {
+                checked: true,
+                disabled: true
+            }
+        },
+        {
+            properties: {
+                id: "checkbox-5",
+                name: "checkbox-name-2",
+                label: "Option Two"
+            },
+            state: {
+                checked: false,
+                disabled: true
+            }
+        },
+        {
+            properties: {
+                id: "checkbox-6",
+                name: "checkbox-name-2",
+                label: "Option Three"
+            },
+            state: {
+                checked: false,
+                disabled: true
+            }
+        }]
+
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+{% endblock %}

--- a/test/templates/format.njk
+++ b/test/templates/format.njk
@@ -1,5 +1,5 @@
 {% macro format(content="") %}
 {{ content }}
 <br><br>
-<textarea>{{ content | e | trim }}</textarea>
+<textarea readonly class="test-textarea">{{ content | e | trim }}</textarea>
 {% endmacro %}

--- a/test/templates/forms.njk
+++ b/test/templates/forms.njk
@@ -1,0 +1,36 @@
+{% macro text(
+    type="text",
+    properties={ value: "", placeholder: "", id: "" },
+    state={ disabled: false, readonly: false, status: "" },
+    aria={},
+    classes=[])
+-%}
+<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="{{type}}" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' readonly' if state.readonly }}>
+{%- endmacro %}
+
+{% macro textarea(
+    properties={ value: "", placeholder: "", id: "" },
+    state={ disabled: false, readonly: false, status: "" },
+    aria={},
+    classes=[])
+-%}
+<textarea class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}" name="{{properties.name}}" {{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' readonly' if state.readonly }}>{{properties.value}}</textarea>
+{%- endmacro %}
+
+{% macro radio(
+    properties={ value: "", id: "" },
+    state={ checked: false, disabled: false, status: "" },
+    aria={},
+    classes=[])
+-%}
+<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="radio" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}>
+{%- endmacro %}
+
+{% macro checkbox(
+    properties={ value: "", id: "" },
+    state={ checked: false, disabled: false, status: "" },
+    aria={},
+    classes=[])
+-%}
+<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="checkbox" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}>
+{%- endmacro %}

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -2,4 +2,5 @@
 <ul>
     <li><a href="button">Button</a></li>
     <li><a href="card">Card</a></li>
+    <li><a href="form">Form</a></li>
 </ul>

--- a/test/templates/layout.njk
+++ b/test/templates/layout.njk
@@ -14,18 +14,18 @@
 #}
 {# <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.4/angular-material.min.css"> #}
     <style media="screen">
-        body { padding: 20px; }
-        textarea { font-family: monospace; height: 200px; width: 100%; padding: 10px; border-color: rgba(0,0,0,0.1); }
         {% set core_sass = 'core.scss' %}
-        {{ core_sass | sassToCss }}
+        {{ core_sass | sass_to_css }}
 
         {% set component_sass = 'components/' + id + '.scss'  %}
-        {{ component_sass | sassToCss }}
+        {{ component_sass | sass_to_css }}
 
         {% for sass in css_deps %}
             {% set dep_sass = sass + '.scss' %}
-            {{ dep_sass | sassToCss }}
+            {{ dep_sass | sass_to_css }}
         {% endfor %}
+        body { padding: 20px; }
+        textarea.test-textarea { font-family: monospace; height: 200px; width: 100%; padding: 10px; font-size: 0.9rem; border: solid 1px rgba(0,0,0,0.1); }
     </style>
 </head>
 <body>


### PR DESCRIPTION
#795 

**All examples can be seen at [localhost:3030/form](http://localhost:3030/form) after starting with `npm test`**

This story implements the `core/forms` styles for all `input` types, including `radio` and `checkbox` and `textarea`.

It also implements the `form` component which primarily arranges the elements inside the `form__group` to stack the label, show the input, put the message below, etc. For this particular component,  the `form` block can be implied, meaning it is not required. In most instances, the `form__group` can be considered the root.

Compare to https://zpl.io/2Gvzk9b, https://zpl.io/25vykjV and https://zpl.io/boeBWWV

This is great but not required ...
```
<form class="tn-form">
  <div class="tn-form__group"></div>
  <div class="tn-form__group"></div>
</form>
```

This is just as good ...
```
  <div class="tn-form__group"></div>
  <div class="tn-form__group"></div>
```

Modifiers may be added to the `form` block later on, currently there are none in place.

## NOTES
- The various types of input text fields have been separated to #875 to cut down on the complexity
- Tooltips next to the label will be added after the tooltip component has been designed
- `input[type=search]` and `input[type=number]` need additional work and will be addressed with the `input-group` story
- There are inconsistencies in how `required` fields are marked in the designs between `radio` and `checkbox`. Marking an individual `label` will bold it, same goes for the `legend`, an `*` must be added manually.
- The default message — not shown — includes no icon, modifiers `help`, `error` or `warning` add the icon to the message.
