### PR TITLE
#875 adds input-group component with addon options; adds button mixin

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -1,3 +1,4 @@
 @import "components/button";
 @import "components/card";
 @import "components/form";
+@import "components/input-group";

--- a/src/styles/components/_mixins.scss
+++ b/src/styles/components/_mixins.scss
@@ -1,0 +1,17 @@
+$ns: ns();
+@mixin tn-button-reset {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+
+}

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -1,6 +1,7 @@
 @import "../core/settings";
 @import "../core/mixins";
 @import "../core/functions";
+@import "mixins";
 
 /*!
 .tn-button+(--small, --large, --icon, --text)+(.is-disabled | [aria-disabled=true])
@@ -24,18 +25,9 @@ $block: ns(button);
     $tn-button-color-text: $tn-color--link !default;
     //BASE
     //set all reset and baseline block styles
+    @include tn-button-reset;
     @include tn-type(2,header,semi);
     line-height: 1;
-    font-smoothing: antialiased;
-    appearance: none;
-    outline: 0;
-    border: 0;
-    display: inline-block;
-    text-decoration: none;
-    cursor: pointer;
-    user-select: none;
-    vertical-align: middle;
-    white-space: nowrap;
     background-color: $tn-button-background-color;
     color: $tn-button-color;
     max-height: tn-space(13);

--- a/src/styles/components/input-group.scss
+++ b/src/styles/components/input-group.scss
@@ -54,7 +54,7 @@ $block: ns(input-group);
         border-style: solid;
         border-width: 1px;
         border-color: $tn-forms-border-color;
-        background-color: $tn-forms-background-color;
+        background-color: tn-color(neutral, 1);
         justify-content: center;
         display: flex;
         flex-direction: column;

--- a/src/styles/components/input-group.scss
+++ b/src/styles/components/input-group.scss
@@ -1,0 +1,123 @@
+@import "../core/settings";
+@import "../core/forms";
+@import "../core/mixins";
+@import "../core/functions";
+@import "mixins";
+
+/*!
+.tn-input-group
+    .tn-input-group__addon+()
+        .tn-input-group__button
+*/
+$block: ns(input-group);
+
+.#{$block} {
+
+    //LOCAL VARS (set all vars used in component, always include !default)
+
+    //BLOCK BASE *******************************************
+    //set all BLOCK reset and baseline styles
+    @include reset;
+    display: flex;
+    max-height: $tn-forms-height--input-text;
+
+    //ELEMENTS *******************************************
+    //set all ELEMENT baseline styles
+    & [type="number"] {
+        &::-webkit-outer-spin-button,
+        &::-webkit-inner-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+        -moz-appearance: textfield;
+    }
+    & [type="search"] {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNiIgaGVpZ2h0PSIyNiI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjNEQ1QTZDIiBkPSJNOS43NTQgMTkuNDk2YTkuNjg0IDkuNjg0IDAgMCAwIDYuMDk3LTIuMTU4bDguMjg5IDguMzRhMS4wODQgMS4wODQgMCAwIDAgMS41MzUtMS41MjlsLTguMy04LjM1YTkuNjg5IDkuNjg5IDAgMCAwIDIuMTItNi4wNTRjMC01LjM3Ny00LjM2OS05Ljc1MS05Ljc0MS05Ljc1MVMuMDEzIDQuMzY4LjAxMyA5Ljc0NXM0LjM2OSA5Ljc1MSA5Ljc0MSA5Ljc1MXptMC0xNy4zMzVjNC4xNzcgMCA3LjU3NyAzLjQwMiA3LjU3NyA3LjU4NCAwIDQuMTgyLTMuNCA3LjU4NC03LjU3NyA3LjU4NC00LjE3OCAwLTcuNTc3LTMuNDAyLTcuNTc3LTcuNTg0IDAtNC4xODIgMy4zOTktNy41ODQgNy41NzctNy41ODR6Ii8+PC9zdmc+');
+        background-repeat: no-repeat;
+        background-position: tn-space(4) center;
+        padding-left: tn-space(15);
+        padding-right: tn-space(15);
+        &::-webkit-search-decoration {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+        &::-webkit-search-cancel-button {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+        -moz-appearance: textfield;
+    }
+    &__addon {
+        @include tn-type(-3, body, bold, normal);
+        color: tn-color(text, 3);
+        padding: 0 tn-space(4);
+        border-style: solid;
+        border-width: 1px;
+        border-color: $tn-forms-border-color;
+        background-color: $tn-forms-background-color;
+        justify-content: center;
+        display: flex;
+        flex-direction: column;
+
+        //ELEMENT MODIFIERS ************
+        //each mod MUST extend the element base
+        &:first-child {
+            border-right-width: 0;
+        }
+        &:last-child {
+            border-left-width: 0;
+        }
+        &--button {
+            padding: 0;
+        }
+        @at-root {
+            [readonly] + & {
+                border-top-color: transparent;
+                border-right-color: transparent;
+            }
+        }
+        @at-root {
+            [type="search"] + & {
+                border: 0;
+                width: 0;
+                //outline: solid 1px red;
+            }
+        }
+
+    }
+    &__button {
+        @include tn-button-reset;
+        flex: 1;
+        width: 100%;
+        display: block;
+        min-width: tn-space(12);
+        &--step-up, &--step-down  {
+            &::after {
+                content: "";
+                position: relative;
+            }
+        }
+        &--step-up {
+            border-bottom: solid 1px $tn-forms-border-color;
+            &::after {
+                @include triangle(13px 8px, black, up);
+                top: -10px;
+            }
+        }
+        &--step-down  {
+            &::after {
+                @include triangle(13px 8px, black, down);
+                top: 10px;
+            }
+        }
+        &--clear {
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNiIgaGVpZ2h0PSIyNiI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjMDA5Q0RGIiBkPSJNMTMgMEM1LjgyIDAgMCA1LjgyIDAgMTNzNS44MiAxMyAxMyAxMyAxMy01LjgyIDEzLTEzUzIwLjE4IDAgMTMgMHptNS4xOTUgMTcuMzk2YS41NjQuNTY0IDAgMSAxLS43OTkuNzk5TDEzIDEzLjc5OWwtNC4zOTYgNC4zOTZhLjU2NC41NjQgMCAxIDEtLjc5OS0uNzk5TDEyLjIwMSAxMyA3LjgwNSA4LjYwNGEuNTY0LjU2NCAwIDEgMSAuNzk5LS43OTlMMTMgMTIuMjAxbDQuMzk2LTQuMzk2YS41NjQuNTY0IDAgMSAxIC43OTkuNzk5TDEzLjc5OSAxM2w0LjM5NiA0LjM5NnoiLz48L3N2Zz4=');
+            background-repeat: no-repeat;
+            background-position: center;
+            position: relative;
+            left: -(tn-space(13));
+        }
+    }
+
+
+}

--- a/test/templates/button/component.njk
+++ b/test/templates/button/component.njk
@@ -1,11 +1,13 @@
 {#
     see ./data.json for object structure
 #}
-{% macro button(properties={}, modifier={}, state={}, aria={}) %}
+{%- macro button(properties={}, modifier={}, state={}, aria={}) -%}
 <button class="tn-button{{ modifier.block | modifier('button') }}{{ ' is-disabled' if state.disabled }}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}>
     {%- if properties.icon %}
     <span class="tn-button__icon{{ modifier.icon | modifier('button__icon') }} tn-icon tn-icon--{{ properties.icon }}" role="presentation"></span>
     {%- endif %}
+    {%- if properties.label %}
     {{properties.label}}
+    {%- endif %}
 </button>
 {%- endmacro %}

--- a/test/templates/button/index.njk
+++ b/test/templates/button/index.njk
@@ -7,168 +7,175 @@
 
 <h1>Button</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['small']
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['large']
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['small']
+        })
+}}
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+        })
+}}
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['large']
+        })
+}}
 {% endset %}
 {{ format(example) }}
 
 <h1>Button — Disabled</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['small']
-            },
-            state={
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['small']
+        },
+        state={
 
-            },
-            aria={
-                disabled: true
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-            },
-            state={
-                disabled: true
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['large']
-            },
-            state={
+        },
+        aria={
+            disabled: true
+        })
+}}
 
-            },
-            aria={
-                disabled: true
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+        },
+        state={
+            disabled: true
+        })
+}}
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['large']
+        },
+        state={
+
+        },
+        aria={
+            disabled: true
+        })
+}}
 {% endset %}
 {{ format(example) }}
 
 <h1>Text Button</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['text','small']
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['text']
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['text','small']
+        })
+}}
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['text']
+        })
+}}
 {% endset %}
 {{ format(example) }}
 
 <h1>Text Button — Disabled</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['text','small']
-            },
-            state={
-                disabled: true
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: ''
-            },
-            modifier={
-                block: ['text']
-            },
-            state={
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['text','small']
+        },
+        state={
+            disabled: true
+        })
+}}
 
-            },
-            aria={
-                disabled: true
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: ''
+        },
+        modifier={
+            block: ['text']
+        },
+        state={
+
+        },
+        aria={
+            disabled: true
+        })
+}}
 {% endset %}
 {{ format(example) }}
 
 
 <h1>Icon Button</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['small','icon']
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['small','icon']
+        })
+}}
 
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['icon']
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['large','icon']
-            })
-    }}
-<br>
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['icon']
+        })
+}}
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['large','icon']
+        })
+}}
+
 {{  button(
         {
             label: 'BUTTON_LABEL',
@@ -196,50 +203,53 @@
 
 <h1>Icon Button — Disabled</h1>
 {% set example %}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['small','icon']
-            },
-            state={
-                disabled: true
-            })
-    }}
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['small','icon']
+        },
+        state={
+            disabled: true
+        })
+}}
 
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['icon']
-            },
-            state={
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['icon']
+        },
+        state={
 
-            },
-            aria={
-                disabled: true
-            })
-    }}
-    {{  button(
-            {
-                label: 'BUTTON_LABEL',
-                icon: 'foo'
-            },
-            modifier={
-                block: ['large','icon']
-            },
-            state={
-                disabled: true
-            },
-            aria={
+        },
+        aria={
+            disabled: true
+        })
+}}
 
-            })
-    }}
-<br>
+
+{{  button(
+        {
+            label: 'BUTTON_LABEL',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['large','icon']
+        },
+        state={
+            disabled: true
+        },
+        aria={
+
+        })
+}}
+
+
 {{  button(
         {
             label: 'BUTTON_LABEL',
@@ -268,7 +278,6 @@
             disabled: true
         })
 }}
-
 {% endset %}
 {{ format(example) }}
 

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -1,6 +1,8 @@
 <h1>Components</h1>
+
 <ul>
     <li><a href="button">Button</a></li>
     <li><a href="card">Card</a></li>
     <li><a href="form">Form</a></li>
+    <li><a href="input-group">Input Group</a></li>
 </ul>

--- a/test/templates/input-group/component.njk
+++ b/test/templates/input-group/component.njk
@@ -1,0 +1,47 @@
+{% import "../forms.njk" as forms %}
+{% from "../button/component.njk" import button %}
+{#
+    see ./data.json for object structure
+#}
+{% macro input_group(
+    type="text",
+    properties={
+        input: {
+            properties: {},
+            state: {},
+            aria: {}
+        },
+        before: "",
+        after: ""
+    },
+    modifier={
+        block: [],
+        before: [],
+        after: []
+    })
+-%}
+{%- set input = properties.input -%}
+<div class="tn-input-group{{ modifier.block | modifier('input-group') }}">
+    {%- if properties.before %}
+    <span class="tn-input-group__addon{{ modifier.before | modifier('input-group__addon') }}">
+{{properties.before}}
+    </span>
+    {%- endif %}
+    {{ forms.text(type,input.properties,state=input.state,aria=input.aria) }}
+    {%- if properties.after %}
+    <span class="tn-input-group__addon{{ modifier.after | modifier('input-group__addon') }}">
+{{ properties.after }}
+    </span>
+    {%- endif %}
+    {%- if type === "number" or type === "search" %}
+    <span class="tn-input-group__addon tn-input-group__addon--button">
+        {%- if type === "number" %}
+        <button class="tn-input-group__button tn-input-group__button--step-up" aria-label="Step up" onclick="document.getElementById('{{input.properties.id}}').stepUp();"></button>
+        <button class="tn-input-group__button tn-input-group__button--step-down" aria-label="Step down" onclick="document.getElementById('{{input.properties.id}}').stepDown();"></button>
+        {%- else %}
+        <button class="tn-input-group__button tn-input-group__button--clear" aria-label="Clear" onclick="document.getElementById('{{input.properties.id}}').value = '';"></button>
+        {%- endif %}
+    </span>
+    {%- endif %}
+</div>
+{% endmacro %}

--- a/test/templates/input-group/data.json
+++ b/test/templates/input-group/data.json
@@ -1,0 +1,13 @@
+{
+    "type": "text",
+    "properties": {
+        "input": "#/forms/text",
+        "before": "",
+        "after": ""
+    },
+    "modifier": {
+        "block": [],
+        "before": ["button"],
+        "after": ["button"]
+    }
+}

--- a/test/templates/input-group/index.njk
+++ b/test/templates/input-group/index.njk
@@ -1,0 +1,244 @@
+{% extends "layout.njk" %}
+{% from "./component.njk" import input_group %}
+{% from "../button/component.njk" import button %}
+{% from "./../format.njk" import format %}
+{% set css_deps = ['helpers','components/button'] %}
+
+{% block content %}
+<style media="screen">
+    .tn-input-group {
+        margin-bottom: 20px;
+    }
+</style>
+
+<h1>Input Group — Text addon</h1>
+{% set example %}
+{{ input_group(
+    properties={
+        after: "km/h",
+        input: {
+            properties: {
+                placeholder: "Field placeholder text"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        after: "km/h",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        after: "€",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        after: "$",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        before: "km/h",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        before: "€",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        before: "$",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+{{ input_group(
+    properties={
+        after: "50",
+        input: {
+            properties: {
+                value: "19387309"
+            }
+        }
+    })
+}}
+
+{% endset %}
+{{ format(example) }}
+
+<br><br>
+
+<h1>Input Group — Special addon</h1>
+
+{% set example %}
+{{ input_group(
+    type="number",
+    properties={
+        input: {
+            properties: {
+                value: "1000000", id: "spinner-1"
+            }
+        }
+    })
+}}
+{{ input_group(
+    type="search",
+    properties={
+        input: {
+            properties: {
+                value: "1000008980283748972894732979327592739572394752397594657843657868436029840932840927349236572635876347239875283472893742980", id: "search-1"
+            }
+        }
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+
+<br><br>
+
+<h1>Input Group — Icon addon</h1>
+{% set example %}
+{{ input_group(
+    properties={
+        input: {
+            properties: {
+                value: "1000000"
+            }
+        },
+        before: '<span class="tn-icon tn-icon--foo tn-has-background-color-text" style="width: 26px; height: 26px;" aria-label=""></span>'
+    })
+}}
+{{ input_group(
+    properties={
+        input: {
+            properties: {
+                value: "1000000"
+            }
+        },
+        after: '<span class="tn-icon tn-icon--foo tn-has-background-color-text" style="width: 26px; height: 26px;" aria-label==""></span>'
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+
+
+<br><br>
+
+<h1>Input Group — Button addon</h1>
+
+{%- set iconbtn %}{{  button(
+        {
+            label: '',
+            icon: 'foo'
+        },
+        modifier={
+            block: ['icon','text']
+        })
+}}{%- endset %}
+{%- set btn %}{{  button(
+        {
+            label: 'Button'
+        },
+        modifier={
+            block: []
+        })
+}}{%- endset %}
+
+{% set example %}
+
+{{ input_group(
+    modifier={
+        after: "button"
+    },
+    properties={
+        input: {
+            properties: {
+                value: "1000000"
+            }
+        },
+        after: iconbtn
+    })
+}}
+{{ input_group(
+    modifier={
+        after: "button"
+    },
+    properties={
+        input: {
+            state: {
+                readonly: true
+            },
+            properties: {
+                value: "1000000"
+            }
+        },
+        after: iconbtn
+    })
+}}
+{{ input_group(
+    modifier={
+        after: "button"
+    },
+    properties={
+        input: {
+            properties: {
+                value: "1000000"
+            }
+        },
+        after: btn
+    })
+}}
+{{ input_group(
+    modifier={
+        after: "button"
+    },
+    properties={
+        input: {
+            properties: {
+                value: "1000000"
+            }
+        },
+        after: button({ icon: 'foo' }, modifier={ block: 'icon' })
+    })
+}}
+{% endset %}
+{{ format(example) }}
+
+
+
+{% endblock %}


### PR DESCRIPTION
#875

> This is currently compared with `feature/795` since it builds on that. I will rebase once that branch is merged.

# Review Notes
### As discussed previously it is not possible with CSS alone to 1) maintain all states of the input field, i.e., hover, active, and 2) have the border wrap the "add-on" content. 

I implemented as Bootstrap does it with standalone-ish add-ons.

![screen shot 2017-08-17 at 3 39 42 pm](https://user-images.githubusercontent.com/424119/29432727-5854ddba-8362-11e7-9c59-b96696b19aed.png)

The design could be implemented if the widths of the `addon` containers are fixed regardless of the content — e.g. "$" and "km/h". The input field content could be padded the add-on content would be shifted on top. However, this would require addt'l classes on the parent container to "tell" the children how they need to behave, which is not desirable. As it is right now, you only have to include the add-on containers if you want them ...
```
<div class="tn-input-group"> 
    <span class="tn-input-group__addon">$</span>
    <input value="">
    <span class="tn-input-group__addon">km/h</span>
</div>
```
vs.
```
<div class="tn-input-group tn-input-group--with-before tn-input-group--with-after"> 
    <span class="tn-input-group__addon">$</span>
    <input value="">
    <span class="tn-input-group__addon">km/h</span>
</div>
```

### Icon only buttons are not working properly, should include these as button types

With the existing buttons it is possible to use only an icon and not include a label but the styling is not correct with an extra margin appearing on the right of the icon.
 
![screen shot 2017-08-17 at 3 41 31 pm](https://user-images.githubusercontent.com/424119/29432899-dd9b0936-8362-11e7-9ae9-d2a66f75a1d5.png)

I recommend adding a new "icon only" button type which would be used here — and would be useful in other places too. There shouldn't be any special CSS needed here for the buttons, it should be a button that could stand on it's own so I'm leaving the margin for now and we can look at the new button separately.




