### PR TITLE
#923 increase specificity of inputs

### DIFF
--- a/scss/components/form.scss
+++ b/scss/components/form.scss
@@ -72,9 +72,10 @@ $block: ns(form);
         }
     }
     &__label, &__legend {
+        @include tn-type(-1);
         display: block;
         margin-bottom: tn-space(3);
-        @include tn-type(-1);
+        border: 0;
         color: tn-color(text, 3);
         &.is-required {
             @include tn-weight(bold);

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -6,8 +6,6 @@
 $elements__headers: h1, h2, h3, h4, h5, h6;
 $elements__blocks: p, ul, ol, li, blockquote, table, figure;
 $elements__interactive: a, audio\[controls\], button, details, embed, iframe, img\[usemap\], input, keygen, label, object\[usemap\], select, textarea, video\[controls\];
-$elements__inputs--text: "input[type=text]", "input[type=password]", "input[type=email]", "input[type=url]", "input[type=search]", "input[type=tel]", "input[type=number]", "input[type=date]";
-$elements__inputs--check: "input[type=radio]", "input[type=checkbox]";
 
 /*!
 * @section Root Element

--- a/scss/core/forms.scss
+++ b/scss/core/forms.scss
@@ -1,8 +1,8 @@
 @import "settings";
 @import "mixins";
 
-$tn-elements-inputs--text: "[type=text]", "[type=password]", "[type=email]", "[type=url]", "[type=search]", "[type=tel]", "[type=number]", "[type=date]";
-$tn-elements-inputs--check: "[type=radio]", "[type=checkbox]";
+$tn-elements-inputs--text: "input[type=text]", "input[type=password]", "input[type=email]", "input[type=url]", "input[type=search]", "input[type=tel]", "input[type=number]", "input[type=date]";
+$tn-elements-inputs--check: "input[type=radio]", "input[type=checkbox]";
 
 //dimensions
 $tn-forms-height--input-text: tn-space(13) !default;
@@ -145,7 +145,7 @@ select {
         background-color: $tn-forms-background-color--disabled;
     }
 }
-[type="checkbox"] {
+input[type="checkbox"] {
     &:checked {
         &::after {
             content: "";
@@ -169,7 +169,7 @@ select {
         }
     }
 }
-[type="radio"] {
+input[type="radio"] {
     border-radius: 50%;
     &::after {
         $check-size_: tn-space(4);


### PR DESCRIPTION
#923 

BS 3 uses `input[type]` selectors instead of `[type]`, so I had to increase the specificity of ours to match.