### PR TITLE
Feature/1115

### DIFF
--- a/scss/all.scss
+++ b/scss/all.scss
@@ -2,6 +2,8 @@
 @import url("//fonts.googleapis.com/css?family=Dosis:400,500,600");
 @import url("//fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700");
 
+//@import "theme/foo";
+
 @import "core";
 @import "layout";
 @import "components";

--- a/scss/components/card-group.scss
+++ b/scss/components/card-group.scss
@@ -19,7 +19,7 @@ $block: ns(card-group);
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
-    @include tn-at-media(s) {
+    @include tn-screen(s) {
         flex-direction: row;
         & > * {
             flex: 1;

--- a/scss/components/toolbar.scss
+++ b/scss/components/toolbar.scss
@@ -53,7 +53,7 @@ $block: ns(toolbar);
             display: flex;
             align-items: center;
             border-top: solid 1px $tn-toolbar-border-color;
-            @include tn-at-media(s) {
+            @include tn-screen(s) {
                 border-top: none;
             }
         }
@@ -69,7 +69,7 @@ $block: ns(toolbar);
             display: flex;
             align-items: center;
         }
-        @include tn-at-media(s) {
+        @include tn-screen(s) {
             &--filter {
                 width: auto;
             }
@@ -90,13 +90,13 @@ $block: ns(toolbar);
     }
     &__pagination {
         margin: 0 auto;
-        @include tn-at-media(s) {
+        @include tn-screen(s) {
             margin-right: tn-space(5);
         }
     }
     &__view-as {
         display: none;
-        @include tn-at-media(s) {
+        @include tn-screen(s) {
             display: block;
             border-left: solid 1px $tn-toolbar-border-color;
         }
@@ -112,7 +112,7 @@ $block: ns(toolbar);
         list-style: none;
         margin-bottom: 0;
         flex-wrap: wrap;
-        @include tn-at-media(xs) {
+        @include tn-screen(xs) {
             display: inline-flex;
             align-items: center;
         }
@@ -122,7 +122,7 @@ $block: ns(toolbar);
         display: flex;
         align-items: center;
         margin-right: tn-space(5);
-        @include tn-at-media(xs) {
+        @include tn-screen(xs) {
             display: inline-flex;
         }
         &::after {

--- a/scss/core/_mixins.scss
+++ b/scss/core/_mixins.scss
@@ -115,7 +115,7 @@ $ns: ns();
     }
 }
 
-@mixin tn-at-media($size, $dimension: width) {
+@mixin tn-screen($size, $dimension: width) {
   @if map-has-key($tn-breakpoints, $size) {
     @media (min-#{$dimension}: map-get($tn-breakpoints, $size)) {
         @content;
@@ -125,7 +125,7 @@ $ns: ns();
   }
 }
 
-@mixin print() {
+@mixin tn-print() {
 	@media print {
 		@content;
 	}

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -2,3 +2,5 @@
 @import "layout/col";
 
 @import "layout/ui";
+@import "layout/app";
+@import "layout/overlay";

--- a/scss/layout/app.scss
+++ b/scss/layout/app.scss
@@ -1,0 +1,52 @@
+@import "../core/settings";
+@import "../core/mixins";
+@import "../core/functions";
+
+$block: ns(app);
+
+/*!
+.tn-app
+    .tn-app__sidebar
+    .tn-app__main
+*/
+
+.#{$block} {
+    $tn-app-sidebar-width: 280px !default;
+    $tn-app-sidebar-height--minimized: 40px !default;
+    $tn-app-sidebar-width--minimized: 80px !default;
+    $tn-app-sidebar-background-color: tn-color(primary, 2) !default;
+    width: 100%;
+    @include tn-screen(s) {
+        display: flex;
+    }
+    &__sidebar {
+        background-color: $tn-app-sidebar-background-color;
+        width: 100vw;
+        max-height: $tn-app-sidebar-height--minimized;
+        &:hover {
+            position: absolute;
+            min-height: 100%;
+        }
+        @include tn-screen(s) {
+            width: $tn-app-sidebar-width--minimized;
+            max-height: 100%;
+            &:hover {
+                width: $tn-app-sidebar-width;
+                position: relative;
+                margin-right: -200px;
+            }
+        }
+        @include tn-screen(l) {
+            width: $tn-app-sidebar-width;
+            &:hover {
+                width: $tn-app-sidebar-width;
+                margin-right: 0;
+            }
+        }
+        overflow: scroll;
+    }
+    &__main {
+        flex: 1;
+        overflow: scroll;
+    }
+}

--- a/scss/layout/col.scss
+++ b/scss/layout/col.scss
@@ -10,7 +10,7 @@ $block: ns(col);
 */
 .#{$block} {
     flex: 1;
-    @include tn-at-media(s) {
+    @include tn-screen(s) {
         @for $i from 1 through 12 {
             &--#{$i} {
                 @include tn-flow($i, 12);

--- a/scss/layout/overlay.scss
+++ b/scss/layout/overlay.scss
@@ -1,0 +1,30 @@
+@import "../core/settings";
+@import "../core/mixins";
+@import "../core/functions";
+
+$block: ns(overlay);
+
+/*!
+.tn-overlay
+
+*/
+
+
+.#{$block} {
+    $tn-overlay-background-color: rgba(black,0.8) !default;
+
+        position: fixed;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        width: 100vw;
+        top: 0;
+        background: $tn-overlay-background-color;
+        z-index: 1000;
+        color: tn-color(text-inverse);
+        &[aria-hidden="true"] {
+            display: none;
+        }
+
+}

--- a/scss/layout/ui.scss
+++ b/scss/layout/ui.scss
@@ -4,32 +4,127 @@
 
 $block: ns(ui);
 
-/*! */
+/*!
+.tn-ui+(--fixed)
+    .tn-ui__header+(--fixed)
+    .tn-ui__app
+    .tn-ui__footer+(--fixed)
+    .tn-ui__overlay
+*/
 
 .#{$block} {
-    $tn-ui-header-height: 60px !default;
-    $tn-ui-header-fixed: true !default;
-    $tn-ui-header-background-color: tn-color(primary) !default;
-    $tn-ui-sidebar-background-color: tn-color(primary,2) !default;
+    //these vars can be set globally to lock all pages
+    //also, --fixed modifiers can be used in the HTML to set per template configurations
+    $tn-ui-fixed: false !default;
+    $tn-ui-header-fixed: false !default;
+    $tn-ui-footer-fixed: false !default;
 
+    $tn-ui-header-height: 60px !default;
+    $tn-ui-header-background-color: tn-color(primary) !default;
+    $tn-ui-footer-height: 40px !default;
+    $tn-ui-footer-background-color: tn-color(primary, 2) !default;
+    $tn-ui-sidebar-width: 280px !default;
+    $tn-ui-sidebar-background-color: tn-color(primary, 2) !default;
+
+    $_ui-is-fixed: $tn-ui-fixed or ($tn-ui-header-fixed and $tn-ui-footer-fixed);
+    position: absolute;
+    min-height: 100vh;
+    width: 100vw;
+    max-width: 100vw;
+    &--fixed {
+        display: flex;
+        flex-direction: column;
+        max-height: 100vh;
+        .#{$block}__header {
+            flex: 0 0 $tn-ui-header-height;
+            position: static;
+        }
+        & .#{$block}__footer {
+            flex: 0 0 $tn-ui-footer-height;
+            position: static;
+        }
+        & .#{$block}__app {
+            overflow: scroll;
+            margin-top: 0;
+            flex: 1;
+            min-height: auto;
+        }
+    }
+    @if $_ui-is-fixed {
+        display: flex;
+        flex-direction: column;
+        max-height: 100vh;
+    }
     &__header {
+        position: absolute;
+        z-index: 1;
         background: $tn-ui-header-background-color;
         width: 100%;
+        min-height: $tn-ui-header-height;
         height: $tn-ui-header-height;
-        position: tn-if($tn-ui-header-fixed, fixed static);
-        top: 0;
+        &--fixed {
+            position: fixed;
+        }
+        @if $_ui-is-fixed {
+            position: static;
+            flex: 0 0 $tn-ui-header-height;
+        } @else {
+            @if $tn-ui-header-fixed {
+                position: fixed;
+            }
+        }
+    }
+    &__footer {
+        background: $tn-ui-footer-background-color;
+        width: 100%;
+        min-height: $tn-ui-footer-height;
+        height: $tn-ui-footer-height;
+        &--fixed {
+            position: fixed;
+            bottom: 0;
+        }
+        @if $_ui-is-fixed {
+            position: static;
+            flex: 0 0 $tn-ui-footer-height;
+        } @else {
+            @if $tn-ui-footer-fixed {
+                position: fixed;
+                bottom: 0;
+            }
+        }
     }
     &__app {
-        margin-top: tn-if($tn-ui-header-fixed, $tn-ui-header-height 0);
-        height: tn-if($tn-ui-header-fixed, calc(100vh - #{$tn-ui-header-height}) 100vh);
-        overflow: scroll;
+        margin-top: $tn-ui-header-height;
+        min-height: calc(100vh - #{$tn-ui-footer-height} - #{$tn-ui-header-height});
+        width: 100%;
         display: flex;
+        position: relative;
+        @if $_ui-is-fixed {
+            overflow: scroll;
+            flex: 1;
+            margin-top: 0;
+        } @else {
+            @if $tn-ui-header-fixed {
+                min-height: calc(100vh - #{$tn-ui-footer-height});
+            }
+            @if $tn-ui-footer-fixed {
+                padding-bottom: $tn-ui-footer-height;
+            }
+        }
     }
     &__sidebar {
-        background: $tn-ui-sidebar-background-color;
+        background-color: $tn-ui-sidebar-background-color;
+        flex: 0 0 $tn-ui-sidebar-width;
+        @if $_ui-is-fixed {
+            overflow: scroll;
+        }
     }
     &__main {
-        flex: 1;
+        @if $_ui-is-fixed {
+            overflow: scroll;
+        }
     }
-
+    &__overlay {
+        position: absolute;
+    }
 }

--- a/scss/theme/foo.scss
+++ b/scss/theme/foo.scss
@@ -1,18 +1,14 @@
-$fonts: (
-  body: #{"'Helvetica Neue'", sans-serif},
-  header: #{"'Times New Roman'", serif},
-  code: #{"Courier", monospace},
+@import "../core/functions";
+
+//fonts
+$tn-fonts: (
+    body: #{Arial, Helvetica, sans-serif},
+    header: #{Arial, Helvetica, sans-serif},
+    code: #{"Courier", sans-serif},
 );
 
-$colors: (
-    lightest: snow,
-    light: gainsboro,
-    dark: dimgray,
-    darkest: midnightblue,
-	action: fuchsia,
-	link: deepskyblue,
-	accent: skyblue,
-    success: lawngreen,
-    warning: darkorange,
-    error: red,
-);
+$tn-background-color: #efefef;
+$tn-ui-fixed: true;
+$tn-ui-header-background-color: black;
+$tn-ui-footer-background-color: darkgray;
+$tn-app-sidebar-background-color: darkred;

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -31,7 +31,9 @@ li {
 
 <h1>Layout</h1>
 <ul>
-    <li><a href="layout">.tn-container | .tn-col</a></li>
+    <li><a href="layout">.tn-container .tn-col</a></li>
+    <li><a href="pages/page">.tn-ui .tn-app</a></li>
+</ul>
 
 <h1>Starter Pages </h1>
 <ul>

--- a/test/templates/pages/layouts/app.njk
+++ b/test/templates/pages/layouts/app.njk
@@ -1,0 +1,24 @@
+{% extends "./ui.njk" %}
+
+{% block app %}
+<div class="tn-app">
+    {% if hide_sidebar !== true %}
+    <div class="tn-app__sidebar">
+        {% block sidebar -%}
+        {%- endblock %}
+    </div>
+    {% endif %}
+    <main class="tn-app__main">
+        {% block main -%}
+        {%- endblock %}
+    </main>
+</div>
+{% endblock %}
+
+{% block header %}
+<strong class="tn-has-color-text-inverse">.tn-ui__header</strong>
+{% endblock %}
+
+{% block footer %}
+<strong class="tn-has-color-text-inverse">.tn-ui__footer</strong>
+{% endblock %}

--- a/test/templates/pages/layouts/master.njk
+++ b/test/templates/pages/layouts/master.njk
@@ -11,18 +11,26 @@
     {{ core_sass | sass_to_css }}
     </style>
 </head>
-<body class="tn-ui tn-ui--{{ app.id }}">
+<body>
+
+<div class="tn-ui tn-ui--{{ app.id }}">
     <div class="tn-ui__header">
         <code class="tn-has-color-inverse">&nbsp;</code>
     </div>
-    <div class="tn-ui__app">
-        <div class="tn-ui__sidebar" style="width: 200px;">
+    <div class="tn-ui__app" id="tn-ui-app">
+        .tn-ui__app
+        {# <div class="tn-ui__sidebar" style="width: 200px;">
             <code class="tn-has-color-inverse">&nbsp;</code>
         </div>
-        <main class="tn-ui__main">
+        <main class="tn-ui__main"> #}
             {% block content %}
             {% endblock %}
-        </main>
+        {# </main> #}
     </div>
+    <div class="tn-overlay" aria-hidden="true" id="tn-ui-overlay">
+        .tn-overlay
+    </div>
+</div>
+
 </body>
 </html>

--- a/test/templates/pages/layouts/ui.njk
+++ b/test/templates/pages/layouts/ui.njk
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8">
+    <!--[if IE]><![endif]-->
+    <meta http-equiv=X-UA-Compatible content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ id }}</title>
+    <style media="screen">
+    {% set core_sass = 'all.scss' %}
+    {{ core_sass | sass_to_css }}
+    </style>
+</head>
+<body>
+    {%- set fix_ui = (fix_footer and fix_header) or (hide_footer and fix_header) %}
+<div class="tn-ui{{ 'fixed' | modifier('ui') if fix_ui }} tn-ui--{{ app.id }}">
+    <div class="tn-ui__header{{ 'fixed' | modifier('ui__header') if fix_header and fix_ui === false }}">
+    {% block header -%}
+    {%- endblock %}
+    </div>
+    <div class="tn-ui__app">
+        {% block app -%}
+        {%- endblock %}
+    </div>
+    {% if hide_footer !== true %}
+    <div class="tn-ui__footer{{ 'fixed' | modifier('ui__footer') if fix_footer and fix_ui === false }}">
+        {% block footer -%}
+        {%- endblock %}
+    </div>
+    {% endif %}
+    {%- if show_overlay %}
+    <div class="tn-ui__overlay tn-overlay" aria-hidden="{{ false if show_overlay else true }}">
+        {% block overlay -%}
+        {%- endblock %}
+    </div>
+    {%- endif %}
+</div>
+</body>
+</html>

--- a/test/templates/pages/page.njk
+++ b/test/templates/pages/page.njk
@@ -1,0 +1,45 @@
+{% extends "./layouts/app.njk" %}
+
+{# ui-level settings #}
+{% set hide_footer = false %}
+{% set fix_header = false %}
+{% set fix_footer = false %}
+
+{% set show_overlay = false %}
+{% block overlay %}
+<strong>.tn-ui__overlay</strong>
+{% endblock %}
+
+{# app-level settings #}
+{# {% set hide_sidebar = false %} #}
+{% block sidebar %}
+
+    <div class="tn-has-color-text-inverse-1" style="width: 200px;">
+        <strong>.tn-app__sidebar</strong>
+        <br><br>
+        <ul>
+            {% for item in range(0,50) %}
+            <li>Vivamus sagittis diam</li>
+            {% endfor %}
+        </ul>
+    </div>
+
+{% endblock %}
+
+{% block main %}
+
+<strong>.tn-app__main</strong>
+<br><br>
+{% for item in range(0,10) %}
+<div class="tn-container tn-has-background-color-neutral-2">
+    <div class="tn-col--6">
+        <p>Nullam ut tincidunt nunc. Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem. </p>
+    </div>
+    <div class="tn-col--6">
+        <p>Suspendisse volutpat felis lectus nec consequat ipsum mattis id. Donec dapibus vehicula facilisis. In tincidunt mi nisi nec faucibus tortor euismod nec. Suspendisse ante ligula aliquet vitae libero eu vulputate dapibus libero. Sed bibendum sapien at posuere interdum libero est sollicitudin magna ac gravida tellus purus eu ipsum. Proin ut quam arcu.</p>
+    </div>
+</div>
+
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
#1115 

See https://github.com/SAP/techne/wiki/Page-Layout-Details

- Changes `tn-at-media` mixin to `tn-screen` for responsive media queries, updated all references in SCSS
- Adds `ui`, `app` and `overlay` layouts SCSS files
- The `ui` component deals only with top-level header, body and footer, as well as an overlay container to cover the entire screen
- The UI blocks can be fixed or static to create various template types, set either globally as SCSS vars or as classes on the elements. The `foo` theme sets a fixed UI for demo purposes.
- The `app` component defines the sidebar and main app content, there is no dependency on the UI and the `app` component could standalone.
- The app sidebar has some responsive behaviors built in (will need refinement and possible some JS assistance as we define what is inside the container†).
- The `overlay` is simple and should fill the entire container with centered content.

In `test/templates/pages/page.njk` set any or all of these to `true` to test variations of the layouts.

```
{% set hide_footer = false %}
{% set fix_header = false %}
{% set fix_footer = false %}

{% set show_overlay = false %}
```
 
Also, replace the commented line for the sidebar to show a full-width layout without a sidebar.

```
{% set hide_sidebar = true %}
```

These base containers intentionally have no padding built in. Child containers will need to do that since each of these must support the ability to bleed a container across the entire width, e.g, the top "back-to" or bottom "legal" section in the sidebar, the action bar and toolbars in the main content area.



_† For example, the app containers could be set to auto width and repsond to the content inside. The navigation inside the container could be minimized and expanded on hover whereas the `app` sidebar would simply pickup the width of the nav. Need to better understand the types of navigation available._