### PR TITLE
#1143 expands disabled state rules

### DIFF
--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -114,7 +114,8 @@ $block: ns(button);
         &[aria-pressed="true"],
         &.is-pressed,
         &[aria-disabled="true"],
-        &.is-disabled {
+        &.is-disabled,
+        &:disabled {
             background-color: transparent;
             outline: none;
             box-shadow: none;
@@ -127,7 +128,8 @@ $block: ns(button);
             color: darken($tn-button-color--text, 10);
         }
         &[aria-disabled="true"],
-        &.is-disabled {
+        &.is-disabled,
+        &:disabled {
             color: $tn-button-color--disabled;
         }
     }
@@ -169,7 +171,8 @@ $block: ns(button);
             }
         }
         &[aria-disabled="true"],
-        &.is-disabled {
+        &.is-disabled,
+        &:disabled {
             &::after {
                 display: none;
             }

--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -45,6 +45,12 @@ $block: ns(dropdown);
         }
         &--no-border {
             border-color: transparent;
+            &[aria-disabled="true"],
+            &.is-disabled,
+            &:disabled {
+                border-color: transparent;
+            }
+
         }
     }
     &__icon {
@@ -90,19 +96,5 @@ $block: ns(dropdown);
         padding-top: tn-space(4);
         border-top: solid 1px tn-color(neutral, 3);
     }
-
-
-
-    //BLOCK MODIFIERS ************
-    //e.g., $tn-dropdown--no-border
-
-
-    //ELEMENTS *******************************************
-    //set all ELEMENT baseline styles
-    //e.g., $tn-dropdown__content
-
-    //STATES *******************************************
-
-
 
 }


### PR DESCRIPTION
#1143 

The `disabled` states shouldn't be used in the `toolbar` — if a control is not available then it should not be present. However, this is a legitimate bug as the `disabled` attribute was not extend to all disabled states.

CSS rules for disabled control should include `&[aria-disabled="true"]`, `&:disabled`, and `&.is-disbaled`. Some CSS declarations did not include all three.

Now fixed.