### PR TITLE
#960 form refactor

### DIFF
--- a/scss/components/form.scss
+++ b/scss/components/form.scss
@@ -4,67 +4,80 @@
 
 /*!
 .tn-form
-    .tn-form__group()
-        .tn-form__legend()
-        .tn-form__item+(--check, --inline)
-            .tn-form__label(.is-required)
-                .tn-inlin-help
-            .tn-form__control((.is-valid | .is-invalid | .is-warning), (.is-disabled|[disabled]), (.is-readonly|[readonly]))
-        .tn-form__message(--help, --error, --warning)
-
+    .tn-form__set?
+        .tn-form__legend(.is-required)
+        .tn-form__group?
+            .tn-form__item+(--check, --inline)
+                .tn-form__label(.is-required)
+                .tn-form__control((.is-valid | .is-invalid | .is-warning), (.is-disabled|[disabled]), (.is-readonly|[readonly]))
+            .tn-form__message(--help, --error, --warning)
 */
 $block: ns(form);
 
 .#{$block} {
     //LOCAL VARS (set all vars used in component, always include !default)
+    $tn-form-label-font-size: -1 !default;
+    $tn-form-label-font-size--check: 0 !default;
+    $tn-form-label-color: tn-color(text, 3) !default;
+    $tn-form-message-font-size: -1 !default;
+    $tn-form-message-color: tn-color(text, 2) !default;
     $tn-form-item-gutter: $tn-width--gutter !default;
+    $tn-form-item-margin-botton: $tn-margin-bottom !default;
 
-    //ELEMENTS *******************************************
-    //set all ELEMENT baseline styles
     &__group {
         @include tn-clearfix;
         @include tn-last-child;
-        margin-bottom: $tn-margin-bottom;
+        .#{$block}__item {
+            @include tn-last-child;
+            margin-right: $tn-form-item-gutter;
+        }
+    }
+    &__set {
+        margin-bottom: $tn-form-item-margin-botton;
+        .#{$block}__item {
+            &--inline {
+                margin-bottom: 0;
+            }
+        }
+        .#{$block}__message {
+            margin-top: tn-space(2);
+        }
     }
     &__item {
-        @include tn-last-child;
-        margin-right: $tn-form-item-gutter;
+        margin-bottom: $tn-margin-bottom;
         &--check {
-            @include tn-clearfix;
             position: relative;
             display: block;
             margin-bottom: tn-space(5);
             .#{$block}__label {
+                @include tn-type($tn-form-label-font-size--check);
                 margin-bottom: 0;
-                margin-top: tn-space(1);
-                float: left;
-                width: calc(100% - #{tn-space(10)});
+                display: inline-block;
+                vertical-align: middle;
             }
             .#{$block}__control {
                 float: left;
-                &:focus {
-                    & + .#{$block}__label {
-                        color: tn-color(text);
-                    }
-                }
+                vertical-align: middle;
+            }
+            .#{$block}__help {
+                float: none;
+                margin-left: tn-space(3);
             }
         }
         &--inline {
             float: left;
-            margin-bottom: 0;
             .#{$block}__label {
                 margin-top: tn-space(1);
-                float: left;
                 width: auto;
             }
         }
     }
     &__label, &__legend {
-        @include tn-type(-1);
+        @include tn-type($tn-form-label-font-size);
         display: block;
-        padding-bottom: tn-space(3);
+        margin-bottom: tn-space(2);
         border: 0;
-        color: tn-color(text, 3);
+        color: $tn-form-label-color;
         &.is-required {
             @include tn-weight(bold);
         }
@@ -72,13 +85,15 @@ $block: ns(form);
     &__legend {
         margin-bottom: tn-space(5);
     }
+    &__help {
+        float: right;
+    }
     &__message {
         clear: both;
         display: block;
-        @include tn-type(-1);
-        color: tn-color(text, 2);
+        @include tn-type($tn-form-message-font-size);
+        color: $tn-form-message-color;
         padding: tn-space(1) 0;
-
         font-style: italic;
         position: relative;
         //adjust for checks

--- a/scss/components/inline-help.scss
+++ b/scss/components/inline-help.scss
@@ -4,7 +4,6 @@
 
 /*!
 .tn-tooltip
-    .tn-tooltip__content
     .tn-tooltip__content+(left, right, bottom-left, bottom-right)
 */
 $block: ns(inline-help);
@@ -24,11 +23,12 @@ $block: ns(inline-help);
     //BLOCK BASE *******************************************
     @include tn-type(-1);
     position: relative;
-    margin-left: tn-space(xs);
+    //margin-left: tn-space(xs);
     display: inline-block;
     width: $tn-tooltip-icon-size;
     height: $tn-tooltip-icon-size;
-    top:3px;
+    top: 3px;
+
     &::before {
         content: "?";
         width: $tn-tooltip-icon-size;
@@ -47,7 +47,7 @@ $block: ns(inline-help);
         @include tn-type(-2)
         background: $tn-tooltip-content-background-color;
         padding: $tn-tooltip-padding;
-        display: inline-block;
+        display: block;
         position: absolute;
         color: $tn-tooltip-content-color;
         top: $tn-tooltip-padding * 2.5;
@@ -92,7 +92,6 @@ $block: ns(inline-help);
             &::before{
                 top: -($tn-tooltip-arrow-offset);
                 left: $tn-tooltip-arrow-offset;
-
             }
         }
     }
@@ -100,6 +99,7 @@ $block: ns(inline-help);
         .#{$block}__content{
             visibility: visible;
             opacity: 1;
+            overflow: visible;
         }
     }
 }

--- a/scss/core/_mixins.scss
+++ b/scss/core/_mixins.scss
@@ -49,7 +49,7 @@ $ns: ns();
         cursor: not-allowed;
         color: $tn-forms-color--disabled;
         border-color: $tn-forms-border-color--disabled;
-        //background-color: $tn-forms-background-color--disabled;
+        background-color: $tn-forms-background-color--disabled;
     }
     &[readonly],
     &.is-readonly {

--- a/scss/core/forms.scss
+++ b/scss/core/forms.scss
@@ -39,6 +39,11 @@ select {
         background-image: none;
         padding-top: $tn-forms-padding;
     }
+    // &[disabled],
+    // &[aria-disabled="true"],
+    // &.is-disabled {
+    //     background-color: $tn-forms-background-color--disabled;
+    // }
 }
 
 #{$tn-elements-inputs--check} {

--- a/test/templates/form/component.njk
+++ b/test/templates/form/component.njk
@@ -1,11 +1,147 @@
 {% import "../forms.njk" as forms %}
+{% import "./../utils.njk" as utils %}
+{% from "./../inline-help/component.njk" import inline_help %}
+
 <!--
-form-group:
+form-set:
     properties={},
     modifier={},
     state={},
     aria={}
 -->
+{% macro form_set(
+    properties={
+        legend: "Form set legend",
+        message: ""
+    },
+    modifier=[])
+-%}
+<fieldset class="tn-form__set">
+    {%- if properties.legend %}
+        <legend class="tn-form__legend{{ ' is-required' if state.required === true }}">{{ properties.legend }}</legend>
+    {%- endif %}
+    <div class="tn-form__group">
+        {{ caller() }}
+    </div>
+    {%- if properties.message %}
+    {{ form_message(properties, modifier.message) }}
+    {%- endif %}
+</fieldset>
+{%- endmacro %}
+
+<!--
+form-item:
+    properties={},
+    modifier={},
+    state={},
+    aria={}
+-->
+{% macro form_item(
+    type="text",
+    properties={
+        label: "Field label",
+        placeholder: "Field placeholder text",
+        name: "",
+        value: "",
+        message: "",
+        help: "",
+        options: [{
+            properties: { label: "Option 1", value: "1" }
+        }]
+    },
+    modifier={ item: [], message: [] },
+    state={ required: false, checked: false, disabled: false, readonly: false, status: "" },
+    aria={})
+-%}
+{%- set _id = utils.id() %}
+<div class="tn-form__item{{ modifier.item | modifier('form__item') }}{{ ' tn-form__item--check' if type == "checkbox" or type == "radio" }}">
+    {%- if type == "checkbox" or type == "radio" %}
+    <label class="tn-form__label{{ ' is-required' if state.required }}" for="{{_id}}">
+        {{ form_control(type,_id,properties,state=state,aria=aria) }}
+        {{ properties.label }}
+        {%- if properties.help %}
+        <span class="tn-form__help">
+            {{ inline_help({ content: properties.help }) }}
+        </span>
+        {%- endif %}
+    </label>
+    {%- else %}
+    <label class="tn-form__label{{ ' is-required' if state.required }}" for="{{_id}}">
+        {{properties.label}}
+        {%- if properties.help %}
+        <span class="tn-form__help">
+            {{ inline_help({ content: properties.help }) }}
+        </span>
+        {%- endif %}
+    </label>
+    {{ form_control(type,_id,properties,state=state,aria=aria) }}
+    {%- endif %}
+    {%- if properties.message %}
+    {{ form_message({ message: properties.message }, modifier=modifier.message) }}
+    {%- endif %}
+</div>
+{%- endmacro %}
+
+<!--
+form-message:
+    properties={ message: "" },
+    modifier=""
+-->
+{% macro form_message(
+    properties={
+        message: "Message text"
+    },
+    modifier="help")
+-%}
+<span class="tn-form__message{{ modifier | modifier('form__message') }}">
+    {{properties.message}}
+</span>
+{%- endmacro %}
+
+<!--
+form-control:
+    properties={},
+    modifier={},
+    state={},
+    aria={}
+-->
+{% macro form_control(
+    type="text",
+    id="",
+    properties={
+        placeholder: "Field placeholder text",
+        name: "",
+        value: "",
+        options: [{
+            properties: { label: "Option 1", value: "1" }
+        }]
+    },
+    modifier={},
+    state={ checked: false, disabled: false, readonly: false, status: "" },
+    aria={})
+-%}
+{%- set props = {
+    id: id,
+    placeholder: properties.placeholder,
+    name: properties.name,
+    value: properties.value,
+    options: properties.options
+} -%}
+{%- if type == "textarea" -%}
+    {{ forms.textarea(props,state=state,aria=aria,classes="form__control") }}
+{%- elif type == "radio" -%}
+    {{ forms.radio(props,state=state,aria=aria,classes=["form__control"]) }}
+{%- elif type == "checkbox" -%}
+    {{ forms.checkbox(props,state=state,aria=aria,classes=["form__control"]) }}
+{%- elif type == "select" -%}
+    {{ forms.select(props,state=state,aria=aria,classes=["form__control"]) }}
+{%- else -%}
+    {{ forms.text(type,props,state=state,aria=aria, classes="form__control") }}
+{%- endif -%}
+{%- endmacro %}
+
+
+{# —————— BELOW ARE DEPRECATED ——————— #}
 {% macro form_group(
     type="text",
     properties={
@@ -49,33 +185,4 @@ form-group:
 </div>
 {%- endif %}
 </{{ 'fieldset' if (type !== 'text' and type !== 'select') else 'div' }}>
-{%- endmacro %}
-
-<!--
-form-control:
-    properties={},
-    modifier={},
-    state={},
-    aria={}
--->
-{% macro form_control(
-    type="text",
-    properties={
-
-    },
-    modifier={},
-    state={},
-    aria={})
--%}
-{%- if type == "textarea" -%}
-    {{ forms.textarea(properties,state=state,aria=aria,classes="form__control") }}
-{%- elif type == "radio" -%}
-    {{ forms.radio(properties,state=state,aria=aria,classes=["form__control"]) }}
-{%- elif type == "checkbox" -%}
-    {{ forms.checkbox(properties,state=state,aria=aria,classes=["form__control"]) }}
-{%- elif type == "select" -%}
-    {{ forms.select(properties,state=state,aria=aria,classes=["form__control"]) }}
-{%- else -%}
-    {{ forms.text(type,properties,state=state,aria=aria, classes="form__control") }}
-{%- endif -%}
 {%- endmacro %}

--- a/test/templates/form/index.njk
+++ b/test/templates/form/index.njk
@@ -1,608 +1,195 @@
 {% extends "layout.njk" %}
-{% from "./component.njk" import form_group, form_control %}
+{% from "./component.njk" import form_control, form_item, form_set %}
+{% import "../forms.njk" as forms %}
 {% from "./../format.njk" import format %}
+{% import "./../utils.njk" as utils %}
+
+<!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
+{% set css_deps = ['components/inline-help'] %}
 
 {% block content %}
-{% set options = [
-    {
-        properties: { label: "Duis malesuada odio volutpat elementum", value: "1" }
-    },
-    {
-        properties: { label: "Suspendisse ante ligula", value: "2" }
-    },
-    {
-        properties: { label: "Sed bibendum sapien at posuere interdum", value: "3" }
-    }
-]
-%}
-<h1>Form — Select</h1>
+
+<h1>.tn-form</h1>
+<p>Form elements are unique in that they can be used independently. In most cases, you will not need a <code>.tn-form</code> wrapper, it can be inferred.</p>
+
+<h2>.tn-form__item</h2>
+<p>A form item is the basic unit for the layout of a form field, which includes a <code>.tn-form__label</code> and <code>.tn-form__control</code> (the field) bound by an id.</p>
+
+<ul>
+    <li>— Indicate a required field with the <code>is-required</code> class on the label.</li>
+    <li>— Indicate status and state of the form field by applying classes or aria attributes to the form control element.</li>
+</ul>
+
+<h3>Text input</h3>
 {% set example %}
-{{ form_group(
-    "select",
-    properties={
-        items: [{
-            properties: {
-                label: "Select Label",
-                value: "Select",
-                id: "select-1",
-                options: options
-            }
-        }]
-    })
-}}
-{{ form_group(
-    "select",
-    properties={
-        items: [{
-            properties: {
-                label: "Select Label",
-                value: "Select",
-                id: "select-2",
-                options: options
-            }
-        }]
-    })
-}}
-{{ form_group(
-    "select",
-    properties={
-        items: [{
-            properties: {
-                label: "Select Label",
-                value: "Select",
-                id: "select-3",
-                options: options
-            },
-            state: {
-                required: true
-            }
-        }]
-    })
-}}
-{{ form_group(
-    "select",
-    properties={
-        items: [{
-            properties: {
-                label: "Select Label",
-                value: "Select",
-                id: "select-4",
-                options: options
-            },
-            state: {
-                disabled: true
-            }
-        }]
-    })
-}}
+{{ form_item() }}
+{{ form_item(state={ required: true }) }}
+{{ form_item(state={ status: "valid" }) }}
+{{ form_item(state={ disabled: true }) }}
+{{ form_item(state={ readonly: true }) }}
 {% endset %}
 {{ format(example) }}
 <br><br>
 
-<h1>Form — Inputs</h1>
+<h3>Select</h3>
 {% set example %}
-{{ form_group(
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-1"
-            }
-        }]
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-2"
-            },
-            state: {
-                required: true
-            }
-        }]
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-3"
-            },
-            state: {
-                status: "valid"
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            modifier: {
-                message: "error"
-            },
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-4",
-                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
-            },
-            state: {
-                status: "invalid"
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            modifier: {
-                message: "warning"
-            },
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-5",
-                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
-            },
-            state: {
-                status: "warning"
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-6"
-            },
-            state: {
-                disabled: true
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-7"
-            },
-            state: {
-                readonly: true
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    properties={
-        items: [{
-            modifier: {
-                message: "help"
-            },
-            properties: {
-                label: "Field Label",
-                placeholder: "Field placeholder text",
-                id: "input-4",
-                message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc"
-            },
-            state: {
-                status: ""
-            }
-        }]
-
-    })
-}}
+{{ form_item("select") }}
+{{ form_item("select", state={ required: true }) }}
+{{ form_item("select", state={ disabled: true }) }}
 {% endset %}
 {{ format(example) }}
 <br><br>
-<h2>Inline</h2>
+
+<h3>Textarea</h3>
 {% set example %}
-{{ form_group(
-    modifier={
-        item: "inline",
-        message: "error"
-    },
-    properties={
-        message: "Error",
-        items: [{
-            properties: {
-                label: "First Name",
-                placeholder: "First Name",
-                id: "input-8"
-            }
-        },
-        {
-            properties: {
-                label: "Last Name",
-                placeholder: "Last Name",
-                id: "input-9"
-            }
-        }]
-    })
-}}
+{{ form_item("textarea", properties={
+        label: "Field Label",
+        value: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem." }) }}
+{% endset %}
+{{ format(example) }}
+<br><br>
+
+
+<h2>.tn-form__item--check</h2>
+<p>Use a <code>--check</code> modifier for <code>radio</code> and <code>checkbox</code> form fields. The same state attributes as above apply. Note: Most often, mutiple radio and checkbox form item elements will be used together. See <code><a href="#form-set">.tn-form__set</a></code> for grouping check-type forms fields.</p>
+
+{% set example %}
+{{ form_item("radio") }}
+{{ form_item("radio",state={ checked: true }) }}
+{{ form_item("radio",state={ required: true }) }}
+{{ form_item("radio",state={ status: "valid" }) }}
+{{ form_item("radio",state={ disabled: true }) }}
 {% endset %}
 {{ format(example) }}
 
 <br><br>
 
-<h1>Form — Textarea</h1>
 {% set example %}
-{{ form_group(
-    "textarea",
-    properties={
-        items: [{
-            properties: {
-                label: "Field Label",
-                value: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem.",
-                id: "textarea-1"
-            }
-        }]
-    })
-}}
+{{ form_item("checkbox") }}
+{{ form_item("checkbox",state={ checked: true }) }}
+{{ form_item("checkbox",state={ required: true }) }}
+{{ form_item("checkbox",state={ status: "valid" }) }}
+{{ form_item("checkbox",state={ disabled: true }) }}
 {% endset %}
 {{ format(example) }}
+
 <br><br>
-<h1>Form — Radio</h1>
-<h2>Stacked (Default)</h2>
+
+<h3>.tn-form__message</h3>
+<p>An optional <code>.tn-form__message</code> element is available inside the form item. A form field class of "is-invalid" or "is-warning" should be included to match the message modifier for "error" and "warning" respectively.</p>
 {% set example %}
-{{ form_group(
-    type="radio",
+{{ form_item(
     properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "radio-1",
-                name: "radio-name-1",
-                label: "Option One"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-2",
-                name: "radio-name-1",
-                label: "Option Two"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "radio-3",
-                name: "radio-name-1",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
-
-    })
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc" }
+    )
 }}
-{{ form_group(
-    type="radio",
+{{ form_item(
     properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "radio-4",
-                name: "radio-name-2",
-                label: "Option One"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "radio-5",
-                name: "radio-name-2",
-                label: "Option Two"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-5",
-                name: "radio-name-2",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
-
-    },
-    state={
-        required: true
-    })
-}}
-{{ form_group(
-    type="radio",
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc" },
     modifier={
         message: "error"
     },
-    properties={
-        legend: "Select an option",
-        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.",
-        items: [
-        {
-            properties: {
-                id: "radio-7",
-                name: "radio-name-3",
-                label: "Option One"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "radio-8",
-                name: "radio-name-3",
-                label: "Option Two"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-9",
-                name: "radio-name-3",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
-
-    })
+    state={ status: "invalid" }
+    )
 }}
-{{ form_group(
-    type="radio",
+{{ form_item(
     properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "radio-10",
-                name: "radio-name-4",
-                label: "Option One"
-            },
-            state: {
-                checked: false,
-                disabled: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-11",
-                name: "radio-name-4",
-                label: "Option Two"
-            },
-            state: {
-                checked: true,
-                disabled: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-12",
-                name: "radio-name-4",
-                label: "Option Three"
-            },
-            state: {
-                checked: false,
-                disabled: true
-            }
-        }]
-
-    })
-}}
-{% endset %}
-{{ format(example) }}
-<br><br>
-<h2>Inline</h2>
-{% set example %}
-{{ form_group(
-    type="radio",
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc" },
     modifier={
-        item: "inline"
-    },
-    properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "radio-13",
-                name: "radio-name-5",
-                label: "Option One"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-14",
-                name: "radio-name-5",
-                label: "Option Two"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "radio-15",
-                name: "radio-name-5",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
-
-    })
-}}
-{{ form_group(
-    type="radio",
-    modifier={
-        item: "inline",
         message: "warning"
     },
-    properties={
-        legend: "Select an option",
-        message: "In tincidunt mi nisi nec faucibus tortor euismod nec. ",
-        items: [
-        {
-            properties: {
-                id: "radio-16",
-                name: "radio-name-6",
-                label: "Option One"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "radio-17",
-                name: "radio-name-6",
-                label: "Option Two"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "radio-18",
-                name: "radio-name-6",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
+    state={ status: "warning" }
+    )
+}}
 
+{{ form_item(
+    properties={
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc" },
+    modifier={
+        message: "help"
+    }
+    )
+}}
+{% endset %}
+{{ format(example) }}
+<br><br>
+
+<h3>.tn-form__help</h3>
+<p>An optional <code>.tn-form__help</code> element is available which should include a <code><a href="inline-help">.tn-inline-help</a></code> component.</p>
+{% set example %}
+{{ form_item(
+    properties={
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        help: "Pellentesque metus lacus commodo eget." }
+    )
+}}
+{{ form_item(
+    properties={
+        label: "Field Label",
+        placeholder: "Field placeholder text",
+        help: "Pellentesque metus lacus commodo eget." },
+    state={
+        readonly: true
     })
 }}
 {% endset %}
 {{ format(example) }}
 <br><br>
 
-<h1>Form — Checkbox</h1>
+
+<h2 id="form-set">.tn-form__set</h2>
+<p>A form set should be used when multiple form items are needed. Most often this will be used for checked elements and grouped form fields like city, state, zip addresses. Use an addt'l <code>.tn-form__group</code> container to wrap the items, e.g., multiple checkboxes. An optional <code>.tn-form__legend</code> can be used as a header.</p>
+
+
 {% set example %}
-{{ form_group(
-    type="checkbox",
-    properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "checkbox-1",
-                name: "checkbox-name-1",
-                label: "Option One"
-            },
-            state: {
-                checked: true
-            }
-        },
-        {
-            properties: {
-                id: "checkbox-2",
-                name: "checkbox-name-1",
-                label: "Option Two"
-            },
-            state: {
-                checked: false
-            }
-        },
-        {
-            properties: {
-                id: "checkbox-3",
-                name: "checkbox-name-1",
-                label: "Option Three"
-            },
-            state: {
-                checked: false
-            }
-        }]
+{% call form_set(properties={
+        legend: "Form set legend"
+    }) %}
+    {{ form_item("radio", { label: "Field label", name: "foo" }) }}
+    {{ form_item("radio", { label: "Field label", name: "foo" }) }}
+    {{ form_item("radio", { label: "Field label", name: "foo" }) }}
+{% endcall %}
 
-    })
-}}
+{% call form_set() %}
+{{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+{{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+{{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+{% endcall %}
 
-{{ form_group(
-    type="checkbox",
-    modifier={
-        item: "inline"
-    },
-    properties={
-        legend: "Select an option",
-        items: [
-        {
-            properties: {
-                id: "checkbox-4",
-                name: "checkbox-name-2",
-                label: "Option One"
-            },
-            state: {
-                checked: true,
-                disabled: true
-            }
-        },
-        {
-            properties: {
-                id: "checkbox-5",
-                name: "checkbox-name-2",
-                label: "Option Two"
-            },
-            state: {
-                checked: false,
-                disabled: true
-            }
-        },
-        {
-            properties: {
-                id: "checkbox-6",
-                name: "checkbox-name-2",
-                label: "Option Three"
-            },
-            state: {
-                checked: false,
-                disabled: true
-            }
-        }]
-
-    })
-}}
+{% call form_set({ }) %}
+    {{ form_item("text", modifier={ item: "inline" }) }}
+    {{ form_item("text", modifier={ item: "inline" }) }}
+{% endcall %}
 {% endset %}
 {{ format(example) }}
+<br><br>
+
+<h3>.tn-form__message</h3>
+<p>Like a <code>.tn-form__item</code> a message can be included for the entire set.</p>
+
+{% set example %}
+{% call form_set(properties={
+        legend: "Form set legend",
+        message: "Pellentesque metus lacus commodo eget justo ut rutrum varius nunc" },
+    modifier={
+        message: "error"
+    }) %}
+    {{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+    {{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+    {{ form_item("radio", { label: "Field label", name: "bar" }, modifier={ item: "inline" }) }}
+{% endcall %}
+{% endset %}
+{{ format(example) }}
+
 
 
 {% endblock %}

--- a/test/templates/forms.njk
+++ b/test/templates/forms.njk
@@ -1,20 +1,35 @@
+{%- macro _field_attrs(
+    properties={ value: "", name: "", id: "" },
+    state={ checked: false, disabled: false, readonly: false, status: "" },
+    aria={},
+    classes=[])
+-%}
+class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}"
+{{- ' name="'+properties.name+'"' if properties.name }}
+{{- aria | aria }}
+{{- ' disabled' if state.disabled }}
+{{- ' readonly' if state.readonly }}
+{{- ' checked' if state.checked }}{{ ' multiple' if state.multiple }}
+{%- endmacro %}
+
 {% macro text(
     type="text",
-    properties={ value: "", placeholder: "", id: "" },
+    properties={ value: "", name: "", placeholder: "", id: "" },
     state={ disabled: false, readonly: false, status: "" },
     aria={},
     classes=[])
 -%}
-<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="{{type}}" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' readonly' if state.readonly }}>
+<input type="{{ type }}" {{ _field_attrs(properties, state, aria, classes) | trim }}{{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' value="'+properties.value+'"' if properties.value }}>
 {%- endmacro %}
 
 {% macro textarea(
-    properties={ value: "", placeholder: "", id: "" },
+    properties={ value: "", name: "", placeholder: "", id: "" },
     state={ disabled: false, readonly: false, status: "" },
     aria={},
     classes=[])
 -%}
-<textarea class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}" name="{{properties.name}}" {{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' readonly' if state.readonly }}>{{properties.value}}</textarea>
+<textarea {{ _field_attrs(properties, state, aria, classes) | trim }}{{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}>{{properties.value}}</textarea>
+{# <textarea class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}" name="{{properties.name}}" {{ ' placeholder="'+properties.placeholder+'"' if properties.placeholder }}{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' readonly' if state.readonly }}>{{properties.value}}</textarea> #}
 {%- endmacro %}
 
 {% macro radio(
@@ -23,7 +38,8 @@
     aria={},
     classes=[])
 -%}
-<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="radio" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}>
+<input type="radio" {{ _field_attrs(properties, state, aria, classes)  | trim }}{{ ' value="'+properties.value+'"' if properties.value }}>
+{# <input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="radio" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}> #}
 {%- endmacro %}
 
 {% macro checkbox(
@@ -32,7 +48,8 @@
     aria={},
     classes=[])
 -%}
-<input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="checkbox" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}>
+<input type="checkbox" {{ _field_attrs(properties, state, aria, classes) | trim }}{{ ' value="'+properties.value+'"' if properties.value }}>
+{# <input class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" type="checkbox" id="{{properties.id}}" name="{{properties.name}}" value="{{properties.value}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' checked' if state.checked }}> #}
 {%- endmacro %}
 
 {% macro select(
@@ -41,7 +58,7 @@
     aria={},
     classes=[])
 -%}
-<select class="{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}" name="{{properties.name}}"{{ ' aria-disabled="'+ aria.disabled +'"' if aria.disabled }}{{ ' disabled' if state.disabled }}{{ ' multiple' if state.multiple }}>
+<select {{ _field_attrs(properties, state, aria, classes) | trim }}>
 {%- for option in properties.options %}
     <option value="{{option.properties.value}}"{{ ' aria-disabled="'+ option.aria.disabled +'"' if aria.disabled }}{{ ' disabled' if option.state.disabled }}>{{option.properties.label}}</option>
 {%- endfor %}

--- a/test/templates/inline-help/component.njk
+++ b/test/templates/inline-help/component.njk
@@ -1,12 +1,14 @@
 <!--
 inline-help:
-    properties={},
+    properties={ content: "" },
     modifier={ block: [] }
 -->
-{% macro inline_help(properties={}, modifier={}, state={}, aria={}) -%}
+{% macro inline_help(properties={
+        content: "Lorem ipsum dolor sit amet."
+    }, modifier={}, state={}, aria={}) -%}
 <span class="tn-inline-help"{{ aria | aria }}>
     <span class="tn-inline-help__content{{ modifier.content | modifier('inline-help__content') }}">
-            {{ properties.content }}
+        {{ properties.content }}
     </span>
 </span>
 {%- endmacro %}


### PR DESCRIPTION
# Previous implementations are not compatible. The documentation examples will break with this CSS.

#960 

http://localhost:3030/form

The primary change here is to allow for a check-type input to be wrapped with a label which is a more common use.

```
<label class="tn-form__label">
    <input type="radio" class="tn-form__control">
    Field label
</label>
```

This also changes the use of `tn-form__group` as a wrapper for multiple form items, e.g., checkboxes use together. The `tn-form__set` is now the higher-level wrapper that can be used to include a legend and a message along with the group of form items. The "set" name is more semantically correct like the native `fieldset` element.

Note that the `form__set` follows a similar pattern as the `form__item` with a legend/label and a message available for multiple form fields just like the `form__item` has these same things for a single field.

Also handles #1106. This allows the `form_item` macro to be used independently, such as a checkbox and label in a `tn-list-group__item`.