### PR TITLE
#1083 implements nav component

### DIFF
--- a/scss/components.scss
+++ b/scss/components.scss
@@ -15,3 +15,4 @@
 @import "components/tree";
 @import "components/list-group";
 @import "components/inline-help";
+@import "components/nav";

--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -60,6 +60,8 @@ $block: ns(dropdown);
     }
     &__menu,
     &__options {
+        padding-left: 0;
+        list-style: none;
         min-width: 100%;
         border: $tn-dropdown-menu-border;
         background: $tn-dropdown-menu-background-color;
@@ -76,11 +78,17 @@ $block: ns(dropdown);
             visibility: hidden;
         }
     }
+    &__group {
+        padding-left: 0;
+        list-style: none;
+    }
     &__item,
     &__option {
         @include reset;
         @include tn-type(-1,body);
         display: block;
+        padding-left: 0;
+        list-style: none;
         padding: $tn-dropdown-menu-item-padding;
         &:hover {
             color: $tn-dropdown-menu-item-color--hover;

--- a/scss/components/list-group.scss
+++ b/scss/components/list-group.scss
@@ -21,6 +21,7 @@ $block: ns(list-group);
 
     @include reset;
     &__item {
+        list-style: none;
         border: 1px solid $tn-list-group-border-color;
         border-top: none;
         padding: $tn-list-group-item-padding;

--- a/scss/components/nav.scss
+++ b/scss/components/nav.scss
@@ -1,0 +1,38 @@
+@import "../core/settings";
+@import "../core/mixins";
+@import "../core/functions";
+
+/*!
+.tn-nav+(--vertical)
+    .tn-nav__item
+    .tn-nav__link+((.is-selected|[aria-selected=true]),(.is-disabled|[aria-disabled=true]))
+*/
+$block: ns(nav);
+
+.#{$block} {
+    $tn-nav-link-padding: tn-space(2);
+    @include reset;
+    display: flex;
+    flex-wrap: wrap;
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+    //MODIFIERS *******************************************
+    &--vertical {
+        flex-direction: column;
+    }
+
+    //ELEMENTS *******************************************
+    &__item {
+
+    }
+    &__link {
+        display: block;
+        padding: $tn-nav-link-padding;
+        &.is-selected,
+        &[aria-selected="true"] {
+            color: $tn-color;
+        }
+    }
+
+}

--- a/scss/components/pagination.scss
+++ b/scss/components/pagination.scss
@@ -22,6 +22,8 @@ $block: ns(pagination);
   @include tn-type(-1);
   display: inline-block;
   margin-bottom: 0;
+  padding-left: 0;
+  list-style: none;
   &__link {
     color: $tn-pagination-color--text;
     background-color: transparent;

--- a/scss/core/_settings.scss
+++ b/scss/core/_settings.scss
@@ -118,7 +118,9 @@ $tn-margin-bottom: tn-space() !default;
 
 //interactive
 $tn-color--link: tn-color(action) !default;
-$tn-color--link-hover: tn-color(action) !default;
+$tn-color--link-hover: darken($tn-color--link, 5) !default;
+$tn-color--link-active: darken($tn-color--link, 10) !default;
+$tn-color--link-disabled: tn-color(text, 2) !default;
 
 //states
 $tn-color--error: tn-color(status, 3) !default;

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -63,8 +63,8 @@ body {
 * Default styles for lists
 */
 ul, ol {
-  padding-left: 0;
-  list-style: none;
+    //padding-left: 0;
+    //list-style: none;
 }
 
 
@@ -87,6 +87,11 @@ a {
     &:focus {
         color: $tn-color--link-hover;
         outline: none;
+    }
+    &[aria-disabled="true"],
+    &.is-disabled {
+        color: $tn-color--link-disabled;
+        cursor: not-allowed;
     }
 }
 

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -63,7 +63,7 @@ body {
 * Default styles for lists
 */
 ul, ol {
-    //padding-left: 0;
+    padding-left: 0;
     //list-style: none;
 }
 

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -22,6 +22,7 @@ li {
     <li><a href="icon">.tn-icon</a></li>
     <li><a href="input-group">.tn-input-group</a></li>
     <li><a href="modal">.tn-modal</a></li>
+    <li><a href="nav">.tn-nav</a></li>
     <li><a href="pagination">.tn-pagination</a></li>
     <li><a href="table">.tn-table</a></li>
     <li><a href="toolbar">.tn-toolbar</a></li>

--- a/test/templates/nav/component.njk
+++ b/test/templates/nav/component.njk
@@ -6,7 +6,7 @@ nav:
     aria={}
 -->
 {% macro nav(properties={}, modifier={}, state={}, aria={}) -%}
-<ul class="tn-nav{{ modifier.block | modifier('nav') }}{{ state | state }}"{{ aria | aria }} role="navigation">
+<ul class="tn-nav{{ modifier.block | modifier('nav') }}{{ state | state }}"{{ aria | aria }}>
     {%- for item in properties.items %}
     <li class="tn-nav__item{{ modifier.item | modifier('nav__item') }}">
         {%- set state = { selected: item.selected, disabled: item.disabled } %}

--- a/test/templates/nav/component.njk
+++ b/test/templates/nav/component.njk
@@ -1,0 +1,23 @@
+<!--
+nav:
+    properties={},
+    modifier={ block: [] },
+    state={},
+    aria={}
+-->
+{% macro nav(properties={}, modifier={}, state={}, aria={}) -%}
+<ul class="tn-nav{{ modifier.block | modifier('nav') }}{{ state | state }}"{{ aria | aria }} role="navigation">
+    {%- for item in properties.items %}
+    <li class="tn-nav__item{{ modifier.item | modifier('nav__item') }}">
+        {%- set state = { selected: item.selected, disabled: item.disabled } %}
+        {%- set aria = {} %}
+        {%- if item.selected %}
+            {%- set aria = { selected: item.selected } %}
+        {%- elif item.disabled %}
+            {%- set aria = { disabled: item.disabled } %}
+        {%- endif %}
+        <a class="tn-nav__link{{ modifier.link | modifier('nav__link') }}{{ state | state }}"{{ aria | aria }} href="{{ item.href or '#' }}">{{ item.label }}</a>
+    </li>
+    {%- endfor %}
+</ul>
+{%- endmacro %}

--- a/test/templates/nav/data.json
+++ b/test/templates/nav/data.json
@@ -1,0 +1,32 @@
+{
+    "id": "nav",
+    "name": "Nav",
+    "properties": {
+        "items": [
+            {
+                "label": "Link"
+            },
+            {
+                "label": "Selected",
+                "selected": true
+            },
+            {
+                "label": "Link"
+            },
+            {
+                "label": "Disabled",
+                "disabled": true
+            }
+        ]
+    },
+    "modifier": {
+        "block": []
+    },
+    "state": {
+
+    },
+    "aria": {
+
+    }
+
+}

--- a/test/templates/nav/index.njk
+++ b/test/templates/nav/index.njk
@@ -1,0 +1,56 @@
+{% extends "layout.njk" %}
+{% from "./../format.njk" import format %}
+{% from "../button/component.njk" import button %}
+{% from "./component.njk" import nav %}
+
+<!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
+{% set css_deps = [] %}
+
+{% block content %}
+
+    <h1>nav</h1>
+    <p>NOTE: The <code>.tn-form__item</code> conatainer is optional. You can use <code>nav</code> and <code>a</code> elements to the same effect.</p>
+
+    <h2>horizontal</h2>
+
+    <!-- output the component example and the code snippet -->
+    {% set example %}
+    {{  nav(
+            data.properties
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+<br><br>
+
+{% set example %}
+<nav class="tn-nav" role="navigation">
+    <a class="tn-nav__link" href="#">Link</a>
+    <a class="tn-nav__link is-selected" aria-selected="true" href="#">Selected</a>
+    <a class="tn-nav__link" href="#">Link</a>
+    <a class="tn-nav__link is-disabled" aria-disabled="true" href="#">Disabled</a>
+</nav>
+{% endset %}
+{{ format(example) }}
+
+
+<br><br>
+
+    <h2>vertical</h2>
+    <!-- output the component example and the code snippet -->
+    {% set example %}
+    {{  nav(
+            data.properties,
+            modifier={
+                block: "vertical"
+            }
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+
+
+
+{% endblock %}


### PR DESCRIPTION
#1083 

This is a building block component upon which the `tn-tabs` will be built. It's pretty simple in what it does. **There is no design spec for this.**

NOTE: I also removed the `list-style: none` rule for `ul, ol` elements. It should be expected that an actual list could be used in an application, so we shouldn't make that difficult. A few SCSS files were updated to address this global change.