### PR TITLE
#1277 forces margin-left: 0 for dropdown menu, options, groups

### DIFF
--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -73,7 +73,8 @@ $block: ns(dropdown);
         opacity: 1;
         visibility: visible;
         transition: opacity $tn-dropdown-menu-item-transition-params;
-        &[aria-hidden="true"] {
+        &[aria-hidden="true"],
+        &.is-hidden {
             opacity: 0;
             visibility: hidden;
         }

--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -50,7 +50,6 @@ $block: ns(dropdown);
             &:disabled {
                 border-color: transparent;
             }
-
         }
     }
     &__icon {
@@ -60,6 +59,7 @@ $block: ns(dropdown);
     }
     &__menu,
     &__options {
+        margin-left: 0;
         padding-left: 0;
         list-style: none;
         min-width: 100%;
@@ -79,6 +79,7 @@ $block: ns(dropdown);
         }
     }
     &__group {
+        margin-left: 0;
         padding-left: 0;
         list-style: none;
     }


### PR DESCRIPTION
This was caused by the `fui-site.css` declaring `ul, ol` with global left margin. I forced the dropdown to have no left margin.

#1277

## Went ahead and fixed the small issue #1258 while I was in here.