### PR TITLE
Move Dependencies to DevDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "http://techne.yaas.io/",
   "author": "SAP SE",
   "license": "Apache-2.0",
-  "dependencies": {
+  "devDependencies": {
     "bower": "^1.8.0",
     "browser-sync": "^2.24.5",
     "gulp": "^3.8.11",


### PR DESCRIPTION
When a project installs `techne` it installs all those packages that are required for the library to function which are listed in the `"dependencies"` list of the package.json file. 

The current dependencies that are listed are merely used for development purposes of this library and are not required when published. Some of these dependencies are vulnerable and should not be shipped with the final product, and instead, should be listed as devDependencies, so that they don't get installed.

This PR just move all unnecessary dependencies to devDependencies. 